### PR TITLE
GCP Cloud Run 자동 배포 파이프라인 구축

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Build layer
+FROM azul/zulu-openjdk-alpine:21 as build
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle gradlew /app/
+COPY gradle /app/gradle
+COPY src /app/src
+
+RUN ./gradlew build -x test
+
+# Package layer
+FROM azul/zulu-openjdk-alpine:21-jre
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar /app/app.jar
+
+ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "/app/app.jar"]

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,28 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+  datasource:
+    url: ${LOCAL_DATABASE_URL}
+    username: ${LOCAL_DATABASE_USERNAME}
+    password: ${LOCAL_DATABASE_PASSWORD}
+    driver-class-name: org.h2.Driver
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## 요약

> GCP Cloud Run을 활용한 자동 배포 파이프라인을 구축합니다. 관련 이슈: #3 

## 배포 과정

- `develop` 브랜치에 대한 변경 사항을 감지하도록 트리거를 추가했습니다.
- 변경이 감지되면, `Cloud Build`가 자동으로 `Dockerfile`을 기반으로 이미지를 빌드합니다.
- 빌드된 이미지는 `Artifact Registry`에 저장 및 관리됩니다.
- 최종적으로, 생성된 이미지를 사용하여 `Cloud Run` 환경에 자동으로 배포가 진행됩니다.

개발 단계에서는 외부 트래픽이 발생하지 않기 때문에 콜드 스타트로 인한 영향을 거의 받지 않습니다. 이에 따라, 최소 실행 (컨테이너) 인스턴스 수를 0으로 설정하여 사용하지 않을 때는 컴퓨팅 자원을 사용하지 않도록 구성했습니다. (비용 절감)

## Docker 이미지 최적화

- 기존 약 500MB의 Docker 이미지를 alpine 기반 이미지로 변경하여 용량을 줄였습니다.
- 추가적으로 멀티 스테이지 빌드를 적용하여 빌드 레이어와 실행 레이어를 분리함으로써 이미지 용량을 277MB까지 줄였습니다.
  - 이는 장기적으로 `GCP Artifact Registry`의 저장소 요금을 절감할 수 있고, 네트워크 전송 속도를 향상시킬 수 있을 것 같습니다.

### 단순한 방식

```Dockerfile
### 374.71 MB ###
FROM azul/zulu-openjdk-alpine:21
WORKDIR /app
COPY build/libs/*.jar app.jar
ENTRYPOINT ["java", "-jar", "/app/app.jar"]
```

### 멀티 스테이지 방식

```Dockerfile ###
### 277.49MB
# Build layer
FROM azul/zulu-openjdk-alpine:21 as build
WORKDIR /app
COPY build.gradle settings.gradle gradlew /app/
COPY gradle /app/gradle
COPY src /app/src
RUN ./gradlew build -x test

# Package layer
FROM azul/zulu-openjdk-alpine:21-jre
WORKDIR /app
COPY --from=build /app/build/libs/*.jar /app/app.jar
ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "/app/app.jar"]
```

## 데이터베이스

- 현재 배포 환경에서 데이터베이스 구성 요소를 고민하고 있으며, 임시로 로컬 환경과 똑같이 H2 환경을 사용합니다.
- 편의성을 위해서 `CloudSQL`을 사용할 수 있지만 요금이 저렴하지 않기 때문에 별도의 `VM 인스턴스`를 활용하여 데이터베이스를 관리하게 될 가능성이 높습니다.
- `CloudSQL` : 관리형 데이터베이스로 편리하지만 요금이 높습니다.
- `VM 인스턴스` : 직접 관리로 비용 절감을 기대할 수 있습니다.

### 기타 

> H2 Console Sorry, remote connections ('webAllowOthers') are disabled on this server.

도커 컨테이너 환경에서 H2 콘솔에 접근하려고 할 때 발생하는 문제를 해결하기 위해 `web-allow-others: true` 옵션을 추가합니다.

## 참고 문서

- [Deploying to Cloud Run using Cloud Build - GCP Docs](https://cloud.google.com/build/docs/deploying-builds/deploy-cloud-run)