### PR TITLE
Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package dev.bang.pickcar.auth.controller;
 
+import dev.bang.pickcar.auth.controller.docs.AuthApiDocs;
 import dev.bang.pickcar.auth.controller.facade.AuthFacade;
 import dev.bang.pickcar.auth.dto.LoginRequest;
 import dev.bang.pickcar.auth.dto.TokenResponse;
@@ -15,11 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("auth")
-public class AuthController {
+public class AuthController implements AuthApiDocs {
 
     private final AuthFacade authFacade;
 
     @PostMapping("signup")
+    @Override
     public ResponseEntity<Void> signup(@RequestBody MemberRequest memberRequest) {
         URI resourceUri = URI.create(authFacade.signup(memberRequest));
         return ResponseEntity.created(resourceUri)
@@ -27,6 +29,7 @@ public class AuthController {
     }
 
     @PostMapping("login")
+    @Override
     public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest loginRequest) {
         TokenResponse token = authFacade.login(loginRequest);
         return ResponseEntity.ok(token);

--- a/src/main/java/dev/bang/pickcar/auth/controller/docs/AuthApiDocs.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/docs/AuthApiDocs.java
@@ -1,0 +1,28 @@
+package dev.bang.pickcar.auth.controller.docs;
+
+import dev.bang.pickcar.auth.dto.LoginRequest;
+import dev.bang.pickcar.auth.dto.TokenResponse;
+import dev.bang.pickcar.member.dto.MemberRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Auth", description = "회원가입 및 로그인 API")
+public interface AuthApiDocs {
+
+    @Operation(summary = "회원가입", description = "회원가입을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<Void> signup(MemberRequest memberRequest);
+
+    @Operation(summary = "로그인", description = "로그인을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<TokenResponse> login(LoginRequest loginRequest);
+}

--- a/src/main/java/dev/bang/pickcar/config/SwaggerConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/SwaggerConfig.java
@@ -1,0 +1,94 @@
+package dev.bang.pickcar.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SwaggerProperties.class)
+public class SwaggerConfig {
+
+    private static final String DOCUMENTS_TITLE = "Pick-Car API Documents";
+    private static final String DOCUMENTS_VERSION = "0.0.1";
+    private static final String DOCUMENTS_DESCRIPTION = "Pick-Car API 명세서입니다.";
+    private static final String SERVER_NAME = "Pick-Car";
+    private static final String GITHUB_URL = "https://github.com/PICK-CAR/pick-car-server";
+    private static final String AUTH_NAME = "Authorization";
+
+    private final Environment environment;
+    private final SwaggerProperties swaggerProperties;
+
+    @Bean
+    public OpenAPI createOpenApi() {
+        return new OpenAPI()
+                .info(getInfo())
+                .servers(getServers())
+                .addSecurityItem(getSecurityRequirement())
+                .components(getComponents());
+    }
+
+    private Info getInfo() {
+        return new Info()
+                .title(DOCUMENTS_TITLE)
+                .version("v" + DOCUMENTS_VERSION)
+                .description(DOCUMENTS_DESCRIPTION)
+                .license(getLicense());
+    }
+
+    private License getLicense() {
+        return new License()
+                .name(SERVER_NAME)
+                .url(GITHUB_URL);
+    }
+
+    private List<Server> getServers() {
+        return List.of(getServerByProfile());
+    }
+
+    private Server getServerByProfile() {
+        if (environment.getActiveProfiles().length == 0) {
+            return new Server()
+                    .url(swaggerProperties.localServerUrl())
+                    .description("Local Server");
+        }
+        if (environment.getActiveProfiles()[0].equals("dev")) {
+            return new Server()
+                    .url(swaggerProperties.devServerUrl())
+                    .description("Dev Server");
+        }
+        return new Server()
+                .url(swaggerProperties.localServerUrl())
+                .description("Local Server");
+    }
+
+    private SecurityRequirement getSecurityRequirement() {
+        return new SecurityRequirement()
+                .addList(AUTH_NAME);
+    }
+
+    private Components getComponents() {
+        return new Components()
+                .addSecuritySchemes(AUTH_NAME, getSecurityScheme());
+    }
+
+    private SecurityScheme getSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name(AUTH_NAME)
+                .scheme("Bearer")
+                .bearerFormat("JWT")
+                .description("토큰을 입력해주세요.");
+    }
+}

--- a/src/main/java/dev/bang/pickcar/config/SwaggerProperties.java
+++ b/src/main/java/dev/bang/pickcar/config/SwaggerProperties.java
@@ -1,0 +1,10 @@
+package dev.bang.pickcar.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "swagger")
+public record SwaggerProperties(
+        String localServerUrl,
+        String devServerUrl
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ security:
   jwt:
     secret-key: ${JWT_SECRET_KEY}
     expiration-time: ${JWT_EXPIRATION_TIME}
+
+swagger:
+  dev-server-url: ${SWAGGER_DEV_SERVER_URL}
+  local-server-url: ${SWAGGER_LOCAL_SERVER_URL}


### PR DESCRIPTION
## 요약

> Swagger를 사용하여 API를 문서화합니다. 관련 이슈: #9

## interface 활용

```java
// Swagger 관련 코드
@Tag(name = "Auth", description = "회원가입 및 로그인 API")
public interface AuthApiDocs {

    @Operation(summary = "회원가입", description = "회원가입을 수행합니다.")
    @ApiResponses(value = {
            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
            @ApiResponse(responseCode = "400", description = "잘못된 요청")
    })
    ResponseEntity<Void> signup(MemberRequest memberRequest);
}
```

```java
// 구현체
@RestController
@RequiredArgsConstructor
@RequestMapping("auth")
public class AuthController implements AuthApiDocs {

    private final AuthFacade authFacade;

    @PostMapping("signup")
    @Override
    public ResponseEntity<Void> signup(@RequestBody MemberRequest memberRequest) {
        // 구현 내용
    }
}
```

- Swagger 관련 코드를 인터페이스로 분리하여 구현 클래스의 가독성을 높이고, 문서화와 비즈니스 로직을 명확히 분리하여 유지보수성을 향상시키려고 했습니다. 
- API 문서를 인터페이스로 관리함으로써 추후 변경사항이 발생하더라도 문서와 구현을 독립적으로 관리할 수 있는 장점을 선택했습니다.