### PR TITLE
내 정보 조회 기능 구현

### DIFF
--- a/src/main/java/dev/bang/pickcar/PickCarApplication.java
+++ b/src/main/java/dev/bang/pickcar/PickCarApplication.java
@@ -2,9 +2,7 @@ package dev.bang.pickcar;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class PickCarApplication {
 

--- a/src/main/java/dev/bang/pickcar/auth/jwt/JwtFilter.java
+++ b/src/main/java/dev/bang/pickcar/auth/jwt/JwtFilter.java
@@ -11,8 +11,6 @@ import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -63,18 +61,10 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private UsernamePasswordAuthenticationToken getAuthentication(String memberId, String memberRole) {
         var authorities = getAuthority(memberRole);
-        UserDetails userDetails = getUserDetails(memberId, authorities);
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        return new UsernamePasswordAuthenticationToken(memberId, null, authorities);
     }
 
     private List<SimpleGrantedAuthority> getAuthority(String memberRole) {
         return List.of(new SimpleGrantedAuthority(MEMBER_ROLE_PREFIX + memberRole));
-    }
-
-    private UserDetails getUserDetails(String memberId, List<SimpleGrantedAuthority> authorities) {
-        return User.withUsername(memberId)
-                .authorities(authorities)
-                .password("")
-                .build();
     }
 }

--- a/src/main/java/dev/bang/pickcar/auth/jwt/JwtFilter.java
+++ b/src/main/java/dev/bang/pickcar/auth/jwt/JwtFilter.java
@@ -23,6 +23,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private static final String AUTH_HEADER = "Authorization";
     private static final String TOKEN_TYPE = "Bearer";
+    private static final String MEMBER_ROLE_PREFIX = "ROLE_";
 
     private final TokenProvider tokenProvider;
 
@@ -67,7 +68,7 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private List<SimpleGrantedAuthority> getAuthority(String memberRole) {
-        return List.of(new SimpleGrantedAuthority(memberRole));
+        return List.of(new SimpleGrantedAuthority(MEMBER_ROLE_PREFIX + memberRole));
     }
 
     private UserDetails getUserDetails(String memberId, List<SimpleGrantedAuthority> authorities) {

--- a/src/main/java/dev/bang/pickcar/auth/jwt/TokenProvider.java
+++ b/src/main/java/dev/bang/pickcar/auth/jwt/TokenProvider.java
@@ -2,7 +2,7 @@ package dev.bang.pickcar.auth.jwt;
 
 import dev.bang.pickcar.auth.dto.MemberAuthResponse;
 import dev.bang.pickcar.auth.dto.TokenResponse;
-import dev.bang.pickcar.config.SecurityProperties;
+import dev.bang.pickcar.config.properties.SecurityProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/dev/bang/pickcar/auth/jwt/TokenProvider.java
+++ b/src/main/java/dev/bang/pickcar/auth/jwt/TokenProvider.java
@@ -9,14 +9,16 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@EnableConfigurationProperties(SecurityProperties.class)
 public class TokenProvider {
 
-    private static final String MEMBER_ID_KEY = "memberId";
-    private static final String MEMBER_ROLE_KEY = "memberRole";
+    private static final String MEMBER_ID_KEY = "id";
+    private static final String MEMBER_ROLE_KEY = "role";
 
     private final SecurityProperties securityProperties;
 
@@ -28,7 +30,6 @@ public class TokenProvider {
     private String buildJwtToken(Long memberId, String memberRole) {
         Date validity = calculateExpiration(getExpirationTime());
         return Jwts.builder()
-                .subject(memberId.toString())
                 .claim(MEMBER_ID_KEY, memberId)
                 .claim(MEMBER_ROLE_KEY, memberRole)
                 .expiration(validity)

--- a/src/main/java/dev/bang/pickcar/auth/util/LoginMemberArgumentResolver.java
+++ b/src/main/java/dev/bang/pickcar/auth/util/LoginMemberArgumentResolver.java
@@ -1,0 +1,31 @@
+package dev.bang.pickcar.auth.util;
+
+import java.security.Principal;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(@NonNull MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Principal principal = webRequest.getUserPrincipal();
+        if (principal == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다.");
+        }
+        return Long.valueOf(principal.getName());
+    }
+}

--- a/src/main/java/dev/bang/pickcar/auth/util/LoginMemberId.java
+++ b/src/main/java/dev/bang/pickcar/auth/util/LoginMemberId.java
@@ -1,0 +1,11 @@
+package dev.bang.pickcar.auth.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface LoginMemberId {
+}

--- a/src/main/java/dev/bang/pickcar/config/JpaAuditingConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package dev.bang.pickcar.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/dev/bang/pickcar/config/SecurityConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package dev.bang.pickcar.config;
 
 import dev.bang.pickcar.auth.jwt.JwtFilter;
+import dev.bang.pickcar.config.properties.SecurityProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/dev/bang/pickcar/config/SwaggerConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package dev.bang.pickcar.config;
 
+import dev.bang.pickcar.config.properties.SwaggerProperties;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;

--- a/src/main/java/dev/bang/pickcar/config/WebConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/WebConfig.java
@@ -1,0 +1,20 @@
+package dev.bang.pickcar.config;
+
+import dev.bang.pickcar.auth.util.LoginMemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/dev/bang/pickcar/config/properties/SecurityProperties.java
+++ b/src/main/java/dev/bang/pickcar/config/properties/SecurityProperties.java
@@ -1,4 +1,4 @@
-package dev.bang.pickcar.config;
+package dev.bang.pickcar.config.properties;
 
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/src/main/java/dev/bang/pickcar/config/properties/SwaggerProperties.java
+++ b/src/main/java/dev/bang/pickcar/config/properties/SwaggerProperties.java
@@ -1,4 +1,4 @@
-package dev.bang.pickcar.config;
+package dev.bang.pickcar.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/dev/bang/pickcar/member/controller/MemberController.java
+++ b/src/main/java/dev/bang/pickcar/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package dev.bang.pickcar.member.controller;
+
+import dev.bang.pickcar.auth.util.LoginMemberId;
+import dev.bang.pickcar.member.controller.docs.MemberApiDocs;
+import dev.bang.pickcar.member.dto.MemberResponse;
+import dev.bang.pickcar.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("members")
+public class MemberController implements MemberApiDocs {
+
+    private final MemberService memberService;
+
+    @GetMapping("me")
+    @PreAuthorize("hasRole('MEMBER')")
+    @Override
+    public ResponseEntity<MemberResponse> myInfo(@LoginMemberId Long id) {
+        return ResponseEntity.ok(memberService.getMemberInfo(id));
+    }
+}

--- a/src/main/java/dev/bang/pickcar/member/controller/docs/MemberApiDocs.java
+++ b/src/main/java/dev/bang/pickcar/member/controller/docs/MemberApiDocs.java
@@ -1,0 +1,20 @@
+package dev.bang.pickcar.member.controller.docs;
+
+import dev.bang.pickcar.member.dto.MemberResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Member", description = "회원 정보 API")
+public interface MemberApiDocs {
+
+    @Operation(summary = "내 정보 조회", description = "내 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내 정보 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<MemberResponse> myInfo(@Parameter(hidden = true) Long id);
+}

--- a/src/main/java/dev/bang/pickcar/member/dto/MemberResponse.java
+++ b/src/main/java/dev/bang/pickcar/member/dto/MemberResponse.java
@@ -1,0 +1,24 @@
+package dev.bang.pickcar.member.dto;
+
+import dev.bang.pickcar.member.entity.Member;
+import java.time.LocalDate;
+
+public record MemberResponse(
+        long memberId,
+        String email,
+        String name,
+        String nickname,
+        String phoneNumber,
+        LocalDate birthDay
+) {
+    public static MemberResponse from(Member member) {
+        return new MemberResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                member.getNickname(),
+                member.getPhoneNumber(),
+                member.getBirthDay()
+        );
+    }
+}

--- a/src/main/java/dev/bang/pickcar/member/service/MemberService.java
+++ b/src/main/java/dev/bang/pickcar/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package dev.bang.pickcar.member.service;
 
 import dev.bang.pickcar.member.dto.MemberRequest;
+import dev.bang.pickcar.member.dto.MemberResponse;
 import dev.bang.pickcar.member.entity.Member;
 import dev.bang.pickcar.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +19,12 @@ public class MemberService {
         Member member = memberRequest.toMember(encryptedPassword);
         return memberRepository.save(member)
                 .getId();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResponse getMemberInfo(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+        return MemberResponse.from(member);
     }
 }

--- a/src/test/java/dev/bang/pickcar/auth/controller/AuthControllerTest.java
+++ b/src/test/java/dev/bang/pickcar/auth/controller/AuthControllerTest.java
@@ -9,7 +9,7 @@ import static dev.bang.pickcar.member.MemberTestData.VALID_PHONE_NUMBER;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
 
 import dev.bang.pickcar.auth.dto.LoginRequest;
-import dev.bang.pickcar.member.MemberTestData;
+import dev.bang.pickcar.member.MemberTestHelper;
 import dev.bang.pickcar.member.dto.MemberRequest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -35,6 +36,9 @@ class AuthControllerTest {
     @LocalServerPort
     private int port;
 
+    @Autowired
+    private MemberTestHelper memberTestHelper;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -43,7 +47,7 @@ class AuthControllerTest {
     @DisplayName("회원가입 테스트")
     @Test
     void signup() {
-        MemberRequest signupRequest = MemberTestData.createMemberRequest();
+        MemberRequest signupRequest = memberTestHelper.createMemberRequest();
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -58,7 +62,7 @@ class AuthControllerTest {
     @ParameterizedTest
     @NullAndEmptySource
     void shouldThrowException_WhenNameIsInvalid(String invalidName) {
-        MemberRequest signupRequest = MemberTestData.createCustomMemberRequest(
+        MemberRequest signupRequest = memberTestHelper.createCustomMemberRequest(
                 invalidName,
                 VALID_NICKNAME,
                 VALID_EMAIL,
@@ -79,7 +83,7 @@ class AuthControllerTest {
     @ParameterizedTest
     @ValueSource(strings = {"", "\n", "\t", "\r"})
     void shouldThrowException_WhenRequestNicknameIsInvalid(String invalidNickname) {
-        MemberRequest signupRequest = MemberTestData.createCustomMemberRequest(
+        MemberRequest signupRequest = memberTestHelper.createCustomMemberRequest(
                 VALID_NAME,
                 invalidNickname,
                 VALID_EMAIL,
@@ -100,7 +104,7 @@ class AuthControllerTest {
     @ParameterizedTest
     @ValueSource(strings = {"", "\n", "\t", "\r", "invalid", "invalid.com", "invalid@com"})
     void shouldThrowException_WhenRequestEmailIsInvalid(String invalidEmail) {
-        MemberRequest signupRequest = MemberTestData.createCustomMemberRequest(
+        MemberRequest signupRequest = memberTestHelper.createCustomMemberRequest(
                 VALID_NAME,
                 VALID_NICKNAME,
                 invalidEmail,
@@ -121,7 +125,7 @@ class AuthControllerTest {
     @ParameterizedTest
     @ValueSource(strings = {"", "\n", "\t", "\r", "invalid",  "0100000-0000", "01000000000", "010-00000000"})
     void shouldThrowException_WhenRequestPhoneNumberIsInvalid(String invalidPhoneNumber) {
-        MemberRequest signupRequest = MemberTestData.createCustomMemberRequest(
+        MemberRequest signupRequest = memberTestHelper.createCustomMemberRequest(
                 VALID_NAME,
                 VALID_NICKNAME,
                 VALID_EMAIL,
@@ -141,7 +145,7 @@ class AuthControllerTest {
     @DisplayName("로그인 테스트")
     @Test
     void login() {
-        MemberRequest signupRequest = MemberTestData.createMemberRequest();
+        MemberRequest signupRequest = memberTestHelper.createMemberRequest();
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -150,7 +154,7 @@ class AuthControllerTest {
                 .then().log().all()
                 .statusCode(201);
 
-        LoginRequest loginRequest = MemberTestData.createLoginRequest();
+        LoginRequest loginRequest = memberTestHelper.createLoginRequest();
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -163,7 +167,7 @@ class AuthControllerTest {
     @DisplayName("로그인 요청 본문이 올바르지 않은 경우 예외가 발생한다.")
     @ParameterizedTest
     @ValueSource(strings = {
-            ", " + VALID_PASSWORD,
+            " , " + VALID_PASSWORD,
             VALID_EMAIL + ", ",
     })
     void shouldThrowException_WhenLoginRequestBodyIsInvalid(String invalidRequest) {

--- a/src/test/java/dev/bang/pickcar/member/MemberTestData.java
+++ b/src/test/java/dev/bang/pickcar/member/MemberTestData.java
@@ -2,8 +2,6 @@ package dev.bang.pickcar.member;
 
 import static dev.bang.pickcar.member.MemberConstant.PHONE_NUMBER_FORMAT;
 
-import dev.bang.pickcar.auth.dto.LoginRequest;
-import dev.bang.pickcar.member.dto.MemberRequest;
 import java.time.LocalDate;
 
 public class MemberTestData {
@@ -16,34 +14,5 @@ public class MemberTestData {
     public static final String VALID_PHONE_NUMBER = PHONE_NUMBER_FORMAT;
 
     private MemberTestData() {
-    }
-
-    public static MemberRequest createMemberRequest() {
-        return new MemberRequest(
-                VALID_NAME,
-                VALID_NICKNAME,
-                VALID_EMAIL,
-                VALID_PASSWORD,
-                VALID_BIRTHDAY,
-                VALID_PHONE_NUMBER
-        );
-    }
-
-    public static MemberRequest createCustomMemberRequest(Object... args) {
-        return new MemberRequest(
-                (String) args[0],
-                (String) args[1],
-                (String) args[2],
-                (String) args[3],
-                (LocalDate) args[4],
-                (String) args[5]
-        );
-    }
-
-    public static LoginRequest createLoginRequest() {
-        return new LoginRequest(
-                VALID_EMAIL,
-                VALID_PASSWORD
-        );
     }
 }

--- a/src/test/java/dev/bang/pickcar/member/MemberTestHelper.java
+++ b/src/test/java/dev/bang/pickcar/member/MemberTestHelper.java
@@ -1,0 +1,81 @@
+package dev.bang.pickcar.member;
+
+import static dev.bang.pickcar.member.MemberTestData.VALID_BIRTHDAY;
+import static dev.bang.pickcar.member.MemberTestData.VALID_EMAIL;
+import static dev.bang.pickcar.member.MemberTestData.VALID_NAME;
+import static dev.bang.pickcar.member.MemberTestData.VALID_NICKNAME;
+import static dev.bang.pickcar.member.MemberTestData.VALID_PASSWORD;
+import static dev.bang.pickcar.member.MemberTestData.VALID_PHONE_NUMBER;
+
+import dev.bang.pickcar.auth.dto.LoginRequest;
+import dev.bang.pickcar.auth.dto.MemberAuthResponse;
+import dev.bang.pickcar.auth.jwt.TokenProvider;
+import dev.bang.pickcar.member.dto.MemberRequest;
+import dev.bang.pickcar.member.entity.Member;
+import dev.bang.pickcar.member.repository.MemberRepository;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+@Component
+@ActiveProfiles("test")
+public class MemberTestHelper {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    private final AtomicLong counter = new AtomicLong();
+
+    public MemberRequest createMemberRequest() {
+        return new MemberRequest(
+                VALID_NAME,
+                VALID_NICKNAME,
+                VALID_EMAIL,
+                VALID_PASSWORD,
+                VALID_BIRTHDAY,
+                VALID_PHONE_NUMBER
+        );
+    }
+
+    public MemberRequest createCustomMemberRequest(Object... args) {
+        return new MemberRequest(
+                (String) args[0],
+                (String) args[1],
+                (String) args[2],
+                (String) args[3],
+                (LocalDate) args[4],
+                (String) args[5]
+        );
+    }
+
+    public LoginRequest createLoginRequest() {
+        return new LoginRequest(
+                VALID_EMAIL,
+                VALID_PASSWORD
+        );
+    }
+
+    public Member createMember() {
+        long uniqueValue = counter.incrementAndGet();
+        String uniqueEmail = String.format("test%d@example.com", uniqueValue);
+        String uniqueNickname = String.format("tester%d", uniqueValue);
+        return memberRepository.save(new Member(
+                VALID_NAME,
+                uniqueNickname,
+                uniqueEmail,
+                VALID_PASSWORD,
+                VALID_BIRTHDAY,
+                VALID_PHONE_NUMBER
+        ));
+    }
+
+    public String getAccessTokenFromMember(Member member) {
+        MemberAuthResponse authResponse = new MemberAuthResponse(member.getId(), member.getRole().name());
+        return tokenProvider.generateToken(authResponse)
+                .accessToken();
+    }
+}

--- a/src/test/java/dev/bang/pickcar/member/controller/MemberControllerTest.java
+++ b/src/test/java/dev/bang/pickcar/member/controller/MemberControllerTest.java
@@ -1,0 +1,48 @@
+package dev.bang.pickcar.member.controller;
+
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+
+import dev.bang.pickcar.member.MemberTestHelper;
+import dev.bang.pickcar.member.entity.Member;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("MemberController 테스트")
+@ActiveProfiles("test")
+@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MemberControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberTestHelper memberTestHelper;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("내 정보 조회 테스트")
+    @Test
+    void me() {
+        Member member = memberTestHelper.createMember();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(member);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("members/me")
+                .then().log().all()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
## 요약

> 내 정보 조회 기능을 구현합니다. 관련 이슈: #12 

## 내용

- 로그인한 사용자의 id를 가져오는 어노테이션 구현합니다.
- `@PreAuthorize` 어노테이션을 사용하여 역할(권한)을 확인합니다.
- 테스트용 데이터와 테스트용 기능을 분리하여 관리합니다.