### PR TITLE
휴대폰 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,5 +34,20 @@ public class AuthController implements AuthApiDocs {
     public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest loginRequest) {
         TokenResponse token = authFacade.login(loginRequest);
         return ResponseEntity.ok(token);
+    }
+
+    @PostMapping("verification/issue")
+    @Override
+    public ResponseEntity<String> issueVerificationCode(@RequestParam String phoneNumber) {
+        String verificationCode = authFacade.issueVerificationCode(phoneNumber);
+        return ResponseEntity.ok(verificationCode);
+    }
+
+    @PostMapping("verification/verify")
+    @Override
+    public ResponseEntity<Void> verifyVerificationNumber(@RequestParam String phoneNumber) {
+        authFacade.verifyPhoneNumber(phoneNumber);
+        return ResponseEntity.ok()
+                .build();
     }
 }

--- a/src/main/java/dev/bang/pickcar/auth/controller/docs/AuthApiDocs.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/docs/AuthApiDocs.java
@@ -25,4 +25,18 @@ public interface AuthApiDocs {
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     ResponseEntity<TokenResponse> login(LoginRequest loginRequest);
+
+    @Operation(summary = "인증번호 발급", description = "휴대폰 번호 인증을 위한 인증번호를 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증번호 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<String> issueVerificationCode(String phoneNumber);
+
+    @Operation(summary = "인증번호 확인", description = "휴대폰 번호 인증을 위한 인증번호를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증번호 확인 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<Void> verifyVerificationNumber(String phoneNumber);
 }

--- a/src/main/java/dev/bang/pickcar/auth/controller/facade/AuthFacade.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/facade/AuthFacade.java
@@ -4,6 +4,7 @@ import dev.bang.pickcar.auth.dto.LoginRequest;
 import dev.bang.pickcar.auth.dto.MemberAuthResponse;
 import dev.bang.pickcar.auth.dto.TokenResponse;
 import dev.bang.pickcar.auth.service.AuthService;
+import dev.bang.pickcar.auth.service.VerificationService;
 import dev.bang.pickcar.member.dto.MemberRequest;
 import dev.bang.pickcar.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,10 @@ public class AuthFacade {
 
     private final AuthService authService;
     private final MemberService memberService;
+    private final VerificationService verificationService;
 
     public String signup(MemberRequest memberRequest) {
+        verificationService.checkVerifiedPhoneNumber(memberRequest.phoneNumber());
         String encryptedPassword = authService.encryptPassword(memberRequest.password());
         Long memberId = memberService.create(memberRequest, encryptedPassword);
         return MEMBER_RESOURCE_LOCATION + memberId;
@@ -27,5 +30,13 @@ public class AuthFacade {
     public TokenResponse login(LoginRequest loginRequest) {
         MemberAuthResponse authResponse = authService.getMemberAuthDetails(loginRequest.email(), loginRequest.password());
         return authService.issueToken(authResponse);
+    }
+
+    public String issueVerificationCode(String phoneNumber) {
+        return verificationService.generateVerificationCode(phoneNumber);
+    }
+
+    public void verifyPhoneNumber(String phoneNumber) {
+        verificationService.processVerification(phoneNumber);
     }
 }

--- a/src/main/java/dev/bang/pickcar/auth/repository/MemoryVerificationCodeRepository.java
+++ b/src/main/java/dev/bang/pickcar/auth/repository/MemoryVerificationCodeRepository.java
@@ -1,0 +1,37 @@
+package dev.bang.pickcar.auth.repository;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("!test")
+public class MemoryVerificationCodeRepository implements VerificationCodeRepository {
+
+    private final Map<String, String> verificationCodeMap = new HashMap<>();
+    private final Set<String> verifiedPhoneNumbers = new HashSet<>();
+
+    @Override
+    public void save(String phoneNumber, String verificationCode) {
+        verificationCodeMap.put(phoneNumber, verificationCode);
+    }
+
+    @Override
+    public String findByPhoneNumber(String phoneNumber) {
+        return verificationCodeMap.get(phoneNumber);
+    }
+
+    @Override
+    public void completeVerification(String phoneNumber) {
+        verificationCodeMap.remove(phoneNumber);
+        verifiedPhoneNumbers.add(phoneNumber);
+    }
+
+    @Override
+    public boolean existsByVerifiedPhoneNumber(String phoneNumber) {
+        return verifiedPhoneNumbers.contains(phoneNumber);
+    }
+}

--- a/src/main/java/dev/bang/pickcar/auth/repository/MemoryVerificationCodeRepository.java
+++ b/src/main/java/dev/bang/pickcar/auth/repository/MemoryVerificationCodeRepository.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@Profile("!test")
+@Profile("local")
 public class MemoryVerificationCodeRepository implements VerificationCodeRepository {
 
     private final Map<String, String> verificationCodeMap = new HashMap<>();

--- a/src/main/java/dev/bang/pickcar/auth/repository/RedisVerificationCodeRepository.java
+++ b/src/main/java/dev/bang/pickcar/auth/repository/RedisVerificationCodeRepository.java
@@ -1,0 +1,54 @@
+package dev.bang.pickcar.auth.repository;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Profile("dev")
+@RequiredArgsConstructor
+public class RedisVerificationCodeRepository implements VerificationCodeRepository {
+
+    private static final String VERIFICATION_CODE_KEY = "verification-code:";
+    private static final String VERIFIED_PHONE_NUMBER_KEY = "verified-phone:";
+    private static final Duration EXPIRATION = Duration.ofMinutes(10);
+
+    private final RedisTemplate<String, String> verificationCodeTemplate;
+
+    @Transactional
+    @Override
+    public void save(String phoneNumber, String verificationCode) {
+        String key = VERIFICATION_CODE_KEY + phoneNumber;
+        verificationCodeTemplate.opsForValue()
+                .set(key, verificationCode, EXPIRATION);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public String findByPhoneNumber(String phoneNumber) {
+        String key = VERIFICATION_CODE_KEY + phoneNumber;
+        return verificationCodeTemplate.opsForValue()
+                .get(key);
+    }
+
+    @Transactional
+    @Override
+    public void completeVerification(String phoneNumber) {
+        String key = VERIFICATION_CODE_KEY + phoneNumber;
+        verificationCodeTemplate.delete(key);
+
+        String verifiedKey = VERIFIED_PHONE_NUMBER_KEY + phoneNumber;
+        verificationCodeTemplate.opsForValue()
+                .set(verifiedKey, phoneNumber, EXPIRATION);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public boolean existsByVerifiedPhoneNumber(String phoneNumber) {
+        String key = VERIFIED_PHONE_NUMBER_KEY + phoneNumber;
+        return verificationCodeTemplate.hasKey(key);
+    }
+}

--- a/src/main/java/dev/bang/pickcar/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/dev/bang/pickcar/auth/repository/VerificationCodeRepository.java
@@ -1,0 +1,12 @@
+package dev.bang.pickcar.auth.repository;
+
+public interface VerificationCodeRepository {
+
+    void save(String phoneNumber, String verificationCode);
+
+    String findByPhoneNumber(String phoneNumber);
+
+    void completeVerification(String phoneNumber);
+
+    boolean existsByVerifiedPhoneNumber(String phoneNumber);
+}

--- a/src/main/java/dev/bang/pickcar/auth/service/VerificationService.java
+++ b/src/main/java/dev/bang/pickcar/auth/service/VerificationService.java
@@ -1,0 +1,42 @@
+package dev.bang.pickcar.auth.service;
+
+import dev.bang.pickcar.auth.repository.VerificationCodeRepository;
+import dev.bang.pickcar.auth.util.MailReader;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+    private final VerificationCodeRepository verificationCodeRepository;
+    private final MailReader mailReader;
+
+    public String generateVerificationCode(String phoneNumber) {
+        String verificationCode = createUUID();
+        verificationCodeRepository.save(phoneNumber, verificationCode);
+        return verificationCode;
+    }
+
+    private String createUUID() {
+        return UUID.randomUUID()
+                .toString();
+    }
+
+    public void processVerification(String phoneNumber) {
+        String message = mailReader.findLatestMessageBySenderPhoneNumber(phoneNumber);
+        String verificationCode = verificationCodeRepository.findByPhoneNumber(phoneNumber);
+        if (message.contains(verificationCode)) {
+            verificationCodeRepository.completeVerification(phoneNumber);
+            return;
+        }
+        throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
+    }
+
+    public void checkVerifiedPhoneNumber(String phoneNumber) {
+        if (!verificationCodeRepository.existsByVerifiedPhoneNumber(phoneNumber)) {
+            throw new IllegalArgumentException("인증되지 않은 휴대폰 번호입니다.");
+        }
+    }
+}

--- a/src/main/java/dev/bang/pickcar/auth/util/GmailReader.java
+++ b/src/main/java/dev/bang/pickcar/auth/util/GmailReader.java
@@ -1,0 +1,183 @@
+package dev.bang.pickcar.auth.util;
+
+import dev.bang.pickcar.config.properties.MailProperties;
+import jakarta.annotation.PostConstruct;
+import jakarta.mail.*;
+import jakarta.mail.search.*;
+import java.util.Comparator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Properties;
+
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+@EnableConfigurationProperties(MailProperties.class)
+public class GmailReader implements MailReader {
+
+    private static final String PROTOCOL = "imaps";
+    private static final String FOLDER_INBOX = "INBOX";
+    private static final String MIME_TYPE_MULTIPART = "multipart/*";
+    private static final String MIME_TYPE_TEXT_PLAIN = "text/plain";
+    private static final String MIME_TYPE_TEXT_HTML = "text/html";
+    private static final int SEARCH_PERIOD_DAYS = 1;
+    private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+
+    private final MailProperties mailProperties;
+    private Session session;
+    private Store store;
+
+    @PostConstruct
+    private void init() {
+        JavaMailSenderImpl mailSender = createMailSender();
+        session = mailSender.getSession();
+    }
+
+    @Override
+    public String findLatestMessageBySenderPhoneNumber(String phoneNumber) {
+        try {
+            Folder inbox = openInbox();
+            Message latestMessage = findLatestMessageByPhoneNumber(inbox, phoneNumber);
+            if (latestMessage == null) {
+                return null;
+            }
+            return extractMessageContent(latestMessage);
+        } catch (Exception e) {
+            log.error("GmailReader 휴대폰 번호: {}로 이메일 조회 중 오류가 발생했습니다.", phoneNumber, e);
+            throw new IllegalStateException("이메일 조회 중 오류가 발생했습니다.");
+        } finally {
+            closeConnection();
+        }
+    }
+
+    private JavaMailSenderImpl createMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(mailProperties.imapServer());
+        mailSender.setPort(mailProperties.imapPort());
+        mailSender.setUsername(mailProperties.account());
+        mailSender.setPassword(mailProperties.password());
+        mailSender.setProtocol(PROTOCOL);
+        addProps(mailSender);
+        return mailSender;
+    }
+
+    private void addProps(JavaMailSenderImpl mailSender) {
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.store.protocol", PROTOCOL);
+        props.put("mail.imaps.host", mailProperties.imapServer());
+        props.put("mail.imaps.port", mailProperties.imapPort());
+        props.put("mail.imaps.ssl.enable", "true");
+    }
+
+    private Folder openInbox() throws MessagingException {
+        store = session.getStore(PROTOCOL);
+        store.connect(mailProperties.imapServer(), mailProperties.account(), mailProperties.password());
+        Folder inbox = store.getFolder(FOLDER_INBOX);
+        inbox.open(Folder.READ_ONLY);
+        return inbox;
+    }
+
+    /**
+     * 휴대폰 번호로 발신된 메일 찾기, 가장 최근 메일을 반환
+     */
+    private Message findLatestMessageByPhoneNumber(Folder inbox, String phoneNumber) throws MessagingException {
+        Message[] messages = searchMessages(inbox);
+        if (messages.length == 0) {
+            return null;
+        }
+        return findFirstMatchingMessage(messages, phoneNumber);
+    }
+
+    private Message[] searchMessages(Folder inbox) throws MessagingException {
+        SearchTerm searchTerm = createDateSearchTerm();
+        return inbox.search(searchTerm);
+    }
+
+    /**
+     * 메일 검색 기간 설정
+     */
+    private SearchTerm createDateSearchTerm() {
+        ZonedDateTime searchStartTime = ZonedDateTime.now(UTC_ZONE).minusDays(SEARCH_PERIOD_DAYS);
+        Date startDate = Date.from(searchStartTime.toInstant());
+        return new ReceivedDateTerm(ReceivedDateTerm.GT, startDate);
+    }
+
+    private Message findFirstMatchingMessage(Message[] messages, String phoneNumber) {
+        return Arrays.stream(messages)
+                .sorted(getMailDateComparator())
+                .filter(message -> isPhoneNumberMatch(message, phoneNumber))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Comparator<Message> getMailDateComparator() {
+        return (m1, m2) -> {
+            try {
+                return m2.getSentDate().compareTo(m1.getSentDate());
+            } catch (MessagingException e) {
+                log.warn("메일 날짜 비교 중 오류가 발생했습니다.", e);
+                return 0;
+            }
+        };
+    }
+
+    private boolean isPhoneNumberMatch(Message message, String phoneNumber) {
+        try {
+            Address[] fromAddresses = message.getFrom();
+            if (fromAddresses == null || fromAddresses.length == 0) {
+                return false;
+            }
+            return fromAddresses[0].toString().startsWith(phoneNumber);
+        } catch (MessagingException e) {
+            log.warn("휴대폰 번호 발신자 확인 중 오류가 발생했습니다.", e);
+            return false;
+        }
+    }
+
+    private String extractMessageContent(Message message) throws Exception {
+        if (message.isMimeType(MIME_TYPE_MULTIPART)) {
+            return extractMultipartContent(message);
+        }
+        if (message.isMimeType(MIME_TYPE_TEXT_PLAIN) || message.isMimeType(MIME_TYPE_TEXT_HTML)) {
+            return message.getContent().toString();
+        }
+        throw new IllegalArgumentException("지원하지 않는 이메일 형식입니다.");
+    }
+
+    private String extractMultipartContent(Message message) throws Exception {
+        StringBuilder contentBuilder = new StringBuilder();
+        Multipart multipart = (Multipart) message.getContent();
+
+        for (int i = 0; i < multipart.getCount(); i++) {
+            BodyPart part = multipart.getBodyPart(i);
+            if (isTextContent(part)) {
+                contentBuilder.append(part.getContent().toString());
+            }
+        }
+        return contentBuilder.toString();
+    }
+
+    private boolean isTextContent(BodyPart part) throws MessagingException {
+        return part.isMimeType(MIME_TYPE_TEXT_PLAIN) || part.isMimeType(MIME_TYPE_TEXT_HTML);
+    }
+
+    private void closeConnection() {
+        try {
+            if (store != null && store.isConnected()) {
+                store.close();
+            }
+        } catch (MessagingException e) {
+            log.error("GmailReader 연결을 닫는 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/dev/bang/pickcar/auth/util/MailReader.java
+++ b/src/main/java/dev/bang/pickcar/auth/util/MailReader.java
@@ -1,0 +1,6 @@
+package dev.bang.pickcar.auth.util;
+
+public interface MailReader {
+
+    String findLatestMessageBySenderPhoneNumber(String phoneNumber);
+}

--- a/src/main/java/dev/bang/pickcar/config/RedisConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package dev.bang.pickcar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@Profile("dev")
+public class RedisConfig {
+
+    /**
+     * 휴대폰 인증 코드를 임시 저장하기 위한 RedisTemplate 빈 등록입니다.
+     */
+    @Bean
+    public RedisTemplate<String, String> verificationCodeTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/dev/bang/pickcar/config/properties/MailProperties.java
+++ b/src/main/java/dev/bang/pickcar/config/properties/MailProperties.java
@@ -1,0 +1,12 @@
+package dev.bang.pickcar.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "mail")
+public record MailProperties(
+        String imapServer,
+        int imapPort,
+        String account,
+        String password
+) {
+}

--- a/src/main/java/dev/bang/pickcar/member/MemberConstant.java
+++ b/src/main/java/dev/bang/pickcar/member/MemberConstant.java
@@ -10,8 +10,8 @@ public class MemberConstant {
     public static final String BIRTHDAY_REGEX = "\\d{4}-\\d{2}-\\d{2}";
     public static final String BIRTHDAY_FORMAT = "yyyy-MM-dd";
 
-    public static final String PHONE_NUMBER_REGEX = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}";
-    public static final String PHONE_NUMBER_FORMAT = "010-0000-0000";
+    public static final String PHONE_NUMBER_REGEX = "^010\\d{8}$";
+    public static final String PHONE_NUMBER_FORMAT = "01000000000";
 
     private MemberConstant() {
     }

--- a/src/main/java/dev/bang/pickcar/member/repository/MemberRepository.java
+++ b/src/main/java/dev/bang/pickcar/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(@Param("email") String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/dev/bang/pickcar/member/service/MemberService.java
+++ b/src/main/java/dev/bang/pickcar/member/service/MemberService.java
@@ -16,6 +16,9 @@ public class MemberService {
 
     @Transactional
     public Long create(MemberRequest memberRequest, String encryptedPassword) {
+        if (memberRepository.existsByEmail(memberRequest.email())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
         Member member = memberRequest.toMember(encryptedPassword);
         return memberRepository.save(member)
                 .getId();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,6 +10,12 @@ spring:
       hibernate:
         format_sql: true
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
   datasource:
     url: ${LOCAL_DATABASE_URL}
     username: ${LOCAL_DATABASE_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,9 @@ security:
 swagger:
   dev-server-url: ${SWAGGER_DEV_SERVER_URL}
   local-server-url: ${SWAGGER_LOCAL_SERVER_URL}
+
+mail:
+  imap-server: ${MAIL_IMAP_SERVER}
+  imap-port: ${MAIL_IMAP_PORT}
+  account: ${MAIL_ACCOUNT}
+  password: ${MAIL_PASSWORD}

--- a/src/test/java/dev/bang/pickcar/auth/controller/AuthControllerTest.java
+++ b/src/test/java/dev/bang/pickcar/auth/controller/AuthControllerTest.java
@@ -123,7 +123,7 @@ class AuthControllerTest {
 
     @DisplayName("잘못된 휴대폰 번호 형식으로 회원가입 요청을 보내면 예외가 발생한다.")
     @ParameterizedTest
-    @ValueSource(strings = {"", "\n", "\t", "\r", "invalid",  "0100000-0000", "01000000000", "010-00000000"})
+    @ValueSource(strings = {"", "\n", "\t", "\r", "invalid",  "0100000-0000", "010-00000000", "010-0000-0000"})
     void shouldThrowException_WhenRequestPhoneNumberIsInvalid(String invalidPhoneNumber) {
         MemberRequest signupRequest = memberTestHelper.createCustomMemberRequest(
                 VALID_NAME,

--- a/src/test/java/dev/bang/pickcar/auth/repository/TestVerificationCodeRepository.java
+++ b/src/test/java/dev/bang/pickcar/auth/repository/TestVerificationCodeRepository.java
@@ -1,0 +1,35 @@
+package dev.bang.pickcar.auth.repository;
+
+import static dev.bang.pickcar.member.MemberTestData.VALID_PHONE_NUMBER;
+import static dev.bang.pickcar.member.MemberTestData.VERIFICATION_CODE;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 테스트용 인증 코드 저장소입니다.
+ * 테스트 데이터인 VALID_PHONE_NUMBER 를 사용하여 VERIFICATION_CODE 를 반환합니다.
+ * @see dev.bang.pickcar.member.MemberTestData
+ */
+@Repository
+@Profile("test")
+public class TestVerificationCodeRepository implements VerificationCodeRepository {
+
+    @Override
+    public void save(String phoneNumber, String verificationCode) {
+    }
+
+    @Override
+    public String findByPhoneNumber(String phoneNumber) {
+        return VERIFICATION_CODE;
+    }
+
+    @Override
+    public void completeVerification(String phoneNumber) {
+    }
+
+    @Override
+    public boolean existsByVerifiedPhoneNumber(String phoneNumber) {
+        return VALID_PHONE_NUMBER.equals(phoneNumber);
+    }
+}

--- a/src/test/java/dev/bang/pickcar/auth/util/TestMailReader.java
+++ b/src/test/java/dev/bang/pickcar/auth/util/TestMailReader.java
@@ -1,0 +1,20 @@
+package dev.bang.pickcar.auth.util;
+
+import static dev.bang.pickcar.member.MemberTestData.VERIFICATION_CODE;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * 테스트용 메일 리더입니다.
+ * 테스트 데이터인 VERIFICATION_CODE 를 반환합니다.
+ */
+@Component
+@Profile("test")
+public class TestMailReader implements MailReader {
+
+    @Override
+    public String findLatestMessageBySenderPhoneNumber(String phoneNumber) {
+        return VERIFICATION_CODE;
+    }
+}

--- a/src/test/java/dev/bang/pickcar/member/MemberTestData.java
+++ b/src/test/java/dev/bang/pickcar/member/MemberTestData.java
@@ -13,6 +13,8 @@ public class MemberTestData {
     public static final LocalDate VALID_BIRTHDAY = LocalDate.of(2000, 1, 1);
     public static final String VALID_PHONE_NUMBER = PHONE_NUMBER_FORMAT;
 
+    public static final String VERIFICATION_CODE = "123456";
+
     private MemberTestData() {
     }
 }

--- a/src/test/java/dev/bang/pickcar/member/entity/MemberTest.java
+++ b/src/test/java/dev/bang/pickcar/member/entity/MemberTest.java
@@ -168,7 +168,7 @@ class MemberTest {
 
     @DisplayName("회원 생성 시 휴대폰 번호 형식이 올바르지 않은 경우 예외가 발생한다.")
     @ParameterizedTest
-    @ValueSource(strings = {"01000000000", "010-0000-000", "010-0000-00000", "010-0000-000A"})
+    @ValueSource(strings = {"010-0000-0000", "01100000000", "0100000000000", "032-000-0000"})
     void shouldThrowException_WhenPhoneNumberIsNotValid(String phoneNumber) {
         assertThatThrownBy(() ->
                 new Member(


### PR DESCRIPTION
## 요약

> 휴대폰 번호를 사용하는 본인 인증 기능을 구현합니다. 관련 이슈: #11 

## 흐름

사용자가 직접 휴대폰으로 문자를 보내는 방식으로 인증을 수행합니다.

- 클라이언트는 서버에게 휴대폰 번호를 전송하고 인증 번호를 발급 받습니다.
- 클라이언트는 받은 인증번호를 사용자의 휴대폰으로 직접 문자를 전송하게 구성합니다.
- 사용자가 휴대폰으로 문자를 전송한 후 클라이언트는 인증 API를 호출합니다.
  - 인증이 완료되면, 해당 휴대폰 번호로 회원가입을 진행할 수 있는 상태가 됩니다.
  - 아닌 경우 예외가 발생합니다.
- 각 단계마다 만료 기한이 존재합니다.

## 인증번호 저장 관련

- 로컬 메모리 기반으로 구성했습니다.
- 테스트 용도로 dev 배포 환경에 GCP의 MemoryStore 환경을 구성했습니다. (확인 예정)
  - 1GB 용량 기준 `US$47.45/월`의 요금이 발생합니다. GCP 무료 크레딧이 있기 때문에 1~2달 정도는 사용할 예정입니다.