### PR TITLE
차량 모델 관리 기능 구현

### DIFF
--- a/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import dev.bang.pickcar.auth.controller.facade.AuthFacade;
 import dev.bang.pickcar.auth.dto.LoginRequest;
 import dev.bang.pickcar.auth.dto.TokenResponse;
 import dev.bang.pickcar.member.dto.MemberRequest;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class AuthController implements AuthApiDocs {
 
     @PostMapping("signup")
     @Override
-    public ResponseEntity<Void> signup(@RequestBody MemberRequest memberRequest) {
+    public ResponseEntity<Void> signup(@RequestBody @Valid MemberRequest memberRequest) {
         URI resourceUri = URI.create(authFacade.signup(memberRequest));
         return ResponseEntity.created(resourceUri)
                 .build();
@@ -31,7 +32,7 @@ public class AuthController implements AuthApiDocs {
 
     @PostMapping("login")
     @Override
-    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
         TokenResponse token = authFacade.login(loginRequest);
         return ResponseEntity.ok(token);
     }

--- a/src/main/java/dev/bang/pickcar/auth/dto/LoginRequest.java
+++ b/src/main/java/dev/bang/pickcar/auth/dto/LoginRequest.java
@@ -1,7 +1,14 @@
 package dev.bang.pickcar.auth.dto;
 
+import static dev.bang.pickcar.member.MemberConstant.EMAIL_REGEX;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record LoginRequest(
+        @Pattern(regexp = EMAIL_REGEX, message = "이메일 형식에 맞게 입력해주세요.")
         String email,
+        @NotBlank(message = "비밀번호를 입력해주세요.")
         String password
 ) {
 }

--- a/src/main/java/dev/bang/pickcar/car/controller/CarModelManageController.java
+++ b/src/main/java/dev/bang/pickcar/car/controller/CarModelManageController.java
@@ -1,0 +1,62 @@
+package dev.bang.pickcar.car.controller;
+
+import dev.bang.pickcar.car.controller.docs.CarModelManageApiDocs;
+import dev.bang.pickcar.car.dto.CarModelRequest;
+import dev.bang.pickcar.car.dto.CarModelResponse;
+import dev.bang.pickcar.car.service.CarModelManageService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("models")
+public class CarModelManageController implements CarModelManageApiDocs {
+
+    private static final String CAR_MODEL_RESOURCE_LOCATION = "/models/";
+
+    private final CarModelManageService carModelManageService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Override
+    public ResponseEntity<Void> createCarModel(@RequestBody @Valid CarModelRequest carModelRequest) {
+        Long carModelId = carModelManageService.addCarModel(carModelRequest);
+        URI resourceUri = URI.create(CAR_MODEL_RESOURCE_LOCATION + carModelId);
+        return ResponseEntity.created(resourceUri)
+                .build();
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Override
+    public ResponseEntity<List<CarModelResponse>> getCarModels() {
+        return ResponseEntity.ok(carModelManageService.getCarModels());
+    }
+
+    @GetMapping("{carModelId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Override
+    public ResponseEntity<CarModelResponse> getCarModel(@PathVariable Long carModelId) {
+        return ResponseEntity.ok(carModelManageService.getCarModel(carModelId));
+    }
+
+    @DeleteMapping("{carModelId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Override
+    public ResponseEntity<Void> deleteCarModel(@PathVariable Long carModelId) {
+        carModelManageService.deleteCarModel(carModelId);
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/controller/docs/CarModelManageApiDocs.java
+++ b/src/main/java/dev/bang/pickcar/car/controller/docs/CarModelManageApiDocs.java
@@ -1,0 +1,42 @@
+package dev.bang.pickcar.car.controller.docs;
+
+import dev.bang.pickcar.car.dto.CarModelRequest;
+import dev.bang.pickcar.car.dto.CarModelResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "CarModelManage", description = "차량 모델 관리 API (관리자)")
+public interface CarModelManageApiDocs {
+
+    @Operation(summary = "차량 모델 생성", description = "차량 모델을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "차량 모델 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<Void> createCarModel(CarModelRequest carModelRequest);
+
+    @Operation(summary = "차량 모델 목록 조회", description = "모든 차량 모델을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "차량 모델 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<List<CarModelResponse>> getCarModels();
+
+    @Operation(summary = "차량 모델 조회", description = "차량 모델을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "차량 모델 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<CarModelResponse> getCarModel(Long carModelId);
+
+    @Operation(summary = "차량 모델 삭제", description = "차량 모델을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "차량 모델 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<Void> deleteCarModel(Long carModelId);
+}

--- a/src/main/java/dev/bang/pickcar/car/dto/CarModelRequest.java
+++ b/src/main/java/dev/bang/pickcar/car/dto/CarModelRequest.java
@@ -1,0 +1,35 @@
+package dev.bang.pickcar.car.dto;
+
+import dev.bang.pickcar.car.entity.CarModel;
+import dev.bang.pickcar.car.entity.CarType;
+import dev.bang.pickcar.car.entity.FuelType;
+import dev.bang.pickcar.car.entity.Segment;
+import jakarta.validation.constraints.NotBlank;
+
+public record CarModelRequest(
+        @NotBlank(message = "브랜드를 입력해주세요.")
+        String brand,
+        @NotBlank(message = "모델명을 입력해주세요.")
+        String name,
+        @NotBlank(message = "세대를 입력해주세요.")
+        String generation,
+        @NotBlank(message = "세그먼트를 입력해주세요. e.g. A, B")
+        String segment,
+        @NotBlank(message = "차량 종류를 입력해주세요. e.g. SEDAN, SUV")
+        String carType,
+        @NotBlank(message = "연료 타입을 입력해주세요. e.g. GASOLINE, DIESEL")
+        String fuelType,
+        int seatCapacity
+) {
+    public CarModel toCarModel() {
+        return new CarModel(
+                brand,
+                name,
+                generation,
+                Segment.from(segment),
+                CarType.from(carType),
+                FuelType.from(fuelType),
+                seatCapacity
+        );
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/dto/CarModelResponse.java
+++ b/src/main/java/dev/bang/pickcar/car/dto/CarModelResponse.java
@@ -1,0 +1,27 @@
+package dev.bang.pickcar.car.dto;
+
+import dev.bang.pickcar.car.entity.CarModel;
+
+public record CarModelResponse(
+        Long id,
+        String brand,
+        String name,
+        String generation,
+        String segment,
+        String carType,
+        String fuelType,
+        int seatCapacity
+) {
+    public static CarModelResponse from(CarModel carModel) {
+        return new CarModelResponse(
+                carModel.getId(),
+                carModel.getBrand(),
+                carModel.getName(),
+                carModel.getGeneration(),
+                carModel.getSegment().name(),
+                carModel.getCarType().name(),
+                carModel.getFuelType().name(),
+                carModel.getSeatCapacity()
+        );
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/entity/CarModel.java
+++ b/src/main/java/dev/bang/pickcar/car/entity/CarModel.java
@@ -1,0 +1,86 @@
+package dev.bang.pickcar.car.entity;
+
+import dev.bang.pickcar.entitiy.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.util.Assert;
+
+@Table(name = "car_models")
+@Entity
+@SQLDelete(sql = "UPDATE car_models SET is_deleted = true WHERE car_model_id = ?")
+@SQLRestriction("is_deleted = false")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CarModel extends BaseTimeEntity {
+
+    private static final int MIN_SEAT_CAPACITY = 0;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "car_model_id")
+    private Long id;
+
+    private String brand;
+
+    private String name;
+
+    private String generation;
+
+    @Enumerated(EnumType.STRING)
+    private Segment segment;
+
+    @Enumerated(EnumType.STRING)
+    private CarType carType;
+
+    @Enumerated(EnumType.STRING)
+    private FuelType fuelType;
+
+    private int seatCapacity;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = Boolean.FALSE;
+
+    public CarModel(String brand,
+                    String name,
+                    String generation,
+                    Segment segment,
+                    CarType carType,
+                    FuelType fuelType,
+                    int seatCapacity) {
+        validate(brand, name, generation, segment, carType, fuelType, seatCapacity);
+        this.brand = brand;
+        this.name = name;
+        this.generation = generation;
+        this.segment = segment;
+        this.carType = carType;
+        this.fuelType = fuelType;
+        this.seatCapacity = seatCapacity;
+    }
+
+    private void validate(String brand,
+                          String name,
+                          String generation,
+                          Segment segment,
+                          CarType carType,
+                          FuelType fuelType,
+                          int seatCapacity) {
+        Assert.hasText(brand, "브랜드를 입력해주세요.");
+        Assert.hasText(name, "모델명을 입력해주세요.");
+        Assert.hasText(generation, "세대를 입력해주세요.");
+        Assert.notNull(segment, "세그먼트를 입력해주세요.");
+        Assert.notNull(carType, "차량 종류를 입력해주세요.");
+        Assert.notNull(fuelType, "연료 타입을 입력해주세요.");
+        Assert.isTrue(seatCapacity > MIN_SEAT_CAPACITY, String.format("좌석 수는 %d보다 많아야 합니다.", MIN_SEAT_CAPACITY));
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/entity/CarType.java
+++ b/src/main/java/dev/bang/pickcar/car/entity/CarType.java
@@ -1,0 +1,30 @@
+package dev.bang.pickcar.car.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum CarType {
+
+    SEDAN("세단"),
+    SUV("SUV"),
+    HATCHBACK("해치백"),
+    TRUCK("트럭"),
+    VAN("밴"),
+    COUPE("쿠페"),
+    CONVERTIBLE("컨버터블"),
+    ;
+
+    private final String description;
+
+    CarType(String description) {
+        this.description = description;
+    }
+
+    public static CarType from(String carType) {
+        try {
+            return CarType.valueOf(carType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효한 차량 종류를 입력해주세요. e.g. SEDAN, SUV, HATCHBACK, TRUCK, VAN, COUPE, CONVERTIBLE");
+        }
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/entity/FuelType.java
+++ b/src/main/java/dev/bang/pickcar/car/entity/FuelType.java
@@ -1,0 +1,29 @@
+package dev.bang.pickcar.car.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum FuelType {
+
+    GASOLINE("가솔린"),
+    DIESEL("디젤"),
+    ELECTRIC("전기"),
+    HYBRID("하이브리드"),
+    LPG("LPG"),
+    HYDROGEN("수소"),
+    ;
+
+    private final String description;
+
+    FuelType(String description) {
+        this.description = description;
+    }
+
+    public static FuelType from(String fuelType) {
+        try {
+            return FuelType.valueOf(fuelType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효한 연료 타입을 입력해주세요. e.g. GASOLINE, DIESEL, ELECTRIC, HYBRID, LPG, HYDROGEN");
+        }
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/entity/Segment.java
+++ b/src/main/java/dev/bang/pickcar/car/entity/Segment.java
@@ -1,0 +1,31 @@
+package dev.bang.pickcar.car.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Segment {
+
+    A("경형", "A"),
+    B("소형", "B"),
+    C("준중형", "C"),
+    D("중형", "D"),
+    E("준대형", "E"),
+    F("대형", "F"),
+    ;
+
+    private final String description;
+    private final String code; // 유럽 자동차 분류 코드 e.g. A-segment
+
+    Segment(String description, String code) {
+        this.description = description;
+        this.code = code;
+    }
+
+    public static Segment from(String code) {
+        try {
+            return Segment.valueOf(code.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효한 세그먼트 코드를 입력해주세요. e.g. A, B, C, D, E, F");
+        }
+    }
+}

--- a/src/main/java/dev/bang/pickcar/car/repository/CarModelRepository.java
+++ b/src/main/java/dev/bang/pickcar/car/repository/CarModelRepository.java
@@ -1,0 +1,25 @@
+package dev.bang.pickcar.car.repository;
+
+import dev.bang.pickcar.car.entity.CarModel;
+import dev.bang.pickcar.car.entity.FuelType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CarModelRepository extends JpaRepository<CarModel, Long> {
+
+    @Query("""
+            SELECT CASE WHEN COUNT(cm) > 0 THEN TRUE ELSE FALSE END
+            FROM CarModel cm
+            WHERE cm.brand = :brand
+              and cm.name = :name
+              and cm.generation = :generation
+              and cm.fuelType = :fuelType
+            """)
+    boolean existsSameCarModel(@Param("brand") String brand,
+                               @Param("name") String name,
+                               @Param("generation") String generation,
+                               @Param("fuelType") FuelType fuelType);
+}

--- a/src/main/java/dev/bang/pickcar/car/service/CarModelManageService.java
+++ b/src/main/java/dev/bang/pickcar/car/service/CarModelManageService.java
@@ -1,0 +1,58 @@
+package dev.bang.pickcar.car.service;
+
+import dev.bang.pickcar.car.dto.CarModelRequest;
+import dev.bang.pickcar.car.dto.CarModelResponse;
+import dev.bang.pickcar.car.entity.CarModel;
+import dev.bang.pickcar.car.entity.FuelType;
+import dev.bang.pickcar.car.repository.CarModelRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CarModelManageService {
+
+    private final CarModelRepository carModelRepository;
+
+    @Transactional
+    public Long addCarModel(CarModelRequest carModelRequest) {
+        checkDuplicateCarModel(carModelRequest.brand(), carModelRequest.name(), carModelRequest.generation(), carModelRequest.fuelType());
+        CarModel carModel = carModelRequest.toCarModel();
+        return carModelRepository.save(carModel)
+                .getId();
+    }
+
+    private void checkDuplicateCarModel(String brand, String name, String generation, String fuelTypeValue) {
+        FuelType fuelType = FuelType.from(fuelTypeValue);
+        if (carModelRepository.existsSameCarModel(brand, name, generation, fuelType)) {
+            throw new IllegalArgumentException("이미 존재하는 차량 모델입니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<CarModelResponse> getCarModels() {
+        List<CarModel> carModels = carModelRepository.findAll();
+        return carModels.stream()
+                .map(CarModelResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CarModelResponse getCarModel(Long carModelId) {
+        CarModel carModel = findModelById(carModelId);
+        return CarModelResponse.from(carModel);
+    }
+
+    private CarModel findModelById(Long carModelId) {
+        return carModelRepository.findById(carModelId)
+                .orElseThrow(() -> new IllegalArgumentException("차량 모델이 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void deleteCarModel(Long carModelId) {
+        CarModel carModel = findModelById(carModelId);
+        carModelRepository.delete(carModel);
+    }
+}

--- a/src/main/java/dev/bang/pickcar/config/SecurityConfig.java
+++ b/src/main/java/dev/bang/pickcar/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -19,8 +20,9 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity
 @EnableConfigurationProperties(SecurityProperties.class)
 public class SecurityConfig {
 

--- a/src/main/java/dev/bang/pickcar/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/bang/pickcar/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package dev.bang.pickcar.exception;
 
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,5 +17,16 @@ public class GlobalExceptionHandler {
         log.warn("IllegalArgumentException: {}", exception.getMessage());
         return ResponseEntity.badRequest()
                 .body(exception.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        log.warn("MethodArgumentNotValidException: {}", exception.getMessage());
+        return ResponseEntity.badRequest()
+                .body(exception.getBindingResult()
+                        .getFieldErrors()
+                        .stream()
+                        .map(FieldError::getDefaultMessage)
+                        .collect(Collectors.joining(", ")));
     }
 }

--- a/src/main/java/dev/bang/pickcar/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/bang/pickcar/exception/GlobalExceptionHandler.java
@@ -27,6 +27,6 @@ public class GlobalExceptionHandler {
                         .getFieldErrors()
                         .stream()
                         .map(FieldError::getDefaultMessage)
-                        .collect(Collectors.joining(", ")));
+                        .collect(Collectors.joining("\n")));
     }
 }

--- a/src/main/java/dev/bang/pickcar/member/dto/MemberRequest.java
+++ b/src/main/java/dev/bang/pickcar/member/dto/MemberRequest.java
@@ -1,7 +1,6 @@
 package dev.bang.pickcar.member.dto;
 
 import static dev.bang.pickcar.member.MemberConstant.BIRTHDAY_FORMAT;
-import static dev.bang.pickcar.member.MemberConstant.BIRTHDAY_REGEX;
 import static dev.bang.pickcar.member.MemberConstant.EMAIL_REGEX;
 import static dev.bang.pickcar.member.MemberConstant.PHONE_NUMBER_FORMAT;
 import static dev.bang.pickcar.member.MemberConstant.PHONE_NUMBER_REGEX;
@@ -9,6 +8,7 @@ import static dev.bang.pickcar.member.MemberConstant.PHONE_NUMBER_REGEX;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dev.bang.pickcar.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 
@@ -22,7 +22,7 @@ public record MemberRequest(
         @NotBlank(message = "비밀번호를 입력해주세요.")
         String password,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = BIRTHDAY_FORMAT, timezone = "Asia/Seoul")
-        @Pattern(regexp = BIRTHDAY_REGEX, message = "생일은 " + BIRTHDAY_FORMAT + " 형식으로 입력해주세요.")
+        @Past(message = "생일은 현재보다 이전 날짜여야 합니다.")
         LocalDate birthDay,
         @Pattern(regexp = PHONE_NUMBER_REGEX, message = "휴대폰 번호는 " + PHONE_NUMBER_FORMAT + " 형식으로 입력해주세요.")
         String phoneNumber

--- a/src/main/java/dev/bang/pickcar/member/entity/Member.java
+++ b/src/main/java/dev/bang/pickcar/member/entity/Member.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 
 @Table(name = "members")
 @Entity
@@ -58,24 +59,26 @@ public class Member extends BaseTimeEntity {
         this.role = MemberRole.MEMBER;
     }
 
+    public Member(String name, String nickname, String email, String password, String phoneNumber, MemberRole role) {
+        validate(name, nickname, email, password, phoneNumber);
+        this.name = name;
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+    }
+
     private void validate(String name, String nickname, String email, String password, String phoneNumber) {
-        validateName(name);
+        Assert.hasText(name, "이름은 필수로 입력해야 합니다.");
         validateNickname(nickname);
         validateEmail(email);
-        validatePassword(password);
+        Assert.hasText(password, "비밀번호는 필수로 입력해야 합니다.");
         validatePhoneNumber(phoneNumber);
     }
 
-    private void validateName(String name) {
-        if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException("이름은 필수로 입력해야 합니다.");
-        }
-    }
-
     private void validateNickname(String nickname) {
-        if (nickname == null || nickname.isEmpty()) {
-            throw new IllegalArgumentException("닉네임은 필수로 입력해야 합니다.");
-        }
+        Assert.hasText(nickname, "닉네임은 필수로 입력해야 합니다.");
         if (nickname.length() < MIN_NICKNAME_LENGTH || nickname.length() > MAX_NICKNAME_LENGTH) {
             throw new IllegalArgumentException(
                     String.format("닉네임은 %d자 이상 %d자 이하로 입력해야 합니다.", MIN_NICKNAME_LENGTH, MAX_NICKNAME_LENGTH));
@@ -83,24 +86,14 @@ public class Member extends BaseTimeEntity {
     }
 
     private void validateEmail(String email) {
-        if (email == null || email.isEmpty()) {
-            throw new IllegalArgumentException("이메일은 필수로 입력해야 합니다.");
-        }
+        Assert.hasText(email, "이메일은 필수로 입력해야 합니다.");
         if (!email.matches(EMAIL_REGEX)) {
             throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
         }
     }
 
-    private void validatePassword(String password) {
-        if (password == null || password.isEmpty()) {
-            throw new IllegalArgumentException("비밀번호는 필수로 입력해야 합니다.");
-        }
-    }
-
     private void validatePhoneNumber(String phoneNumber) {
-        if (phoneNumber == null || phoneNumber.isEmpty()) {
-            throw new IllegalArgumentException("휴대폰 번호는 필수로 입력해야 합니다.");
-        }
+        Assert.hasText(phoneNumber, "휴대폰 번호는 필수로 입력해야 합니다.");
         if (!phoneNumber.matches(PHONE_NUMBER_REGEX)) {
             throw new IllegalArgumentException("휴대폰 번호 형식이 올바르지 않습니다.");
         }

--- a/src/test/java/dev/bang/pickcar/car/CarTestData.java
+++ b/src/test/java/dev/bang/pickcar/car/CarTestData.java
@@ -1,0 +1,19 @@
+package dev.bang.pickcar.car;
+
+import dev.bang.pickcar.car.entity.CarType;
+import dev.bang.pickcar.car.entity.FuelType;
+import dev.bang.pickcar.car.entity.Segment;
+
+public class CarTestData {
+
+    public static final String VALID_CAR_BRAND_NAME = "현대";
+    public static final String VALID_CAR_MODEL_NAME = "쏘나타";
+    public static final String VALID_CAR_GENERATION = "DN8";
+    public static final Segment VALID_CAR_SEGMENT = Segment.D;
+    public static final CarType VALID_CAR_TYPE = CarType.SEDAN;
+    public static final FuelType VALID_FUEL_TYPE = FuelType.GASOLINE;
+    public static final int VALID_CAR_SEAT_CAPACITY = 5;
+
+    private CarTestData() {
+    }
+}

--- a/src/test/java/dev/bang/pickcar/car/CarTestHelper.java
+++ b/src/test/java/dev/bang/pickcar/car/CarTestHelper.java
@@ -1,0 +1,70 @@
+package dev.bang.pickcar.car;
+
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_BRAND_NAME;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_GENERATION;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_MODEL_NAME;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_SEAT_CAPACITY;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_SEGMENT;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_TYPE;
+import static dev.bang.pickcar.car.CarTestData.VALID_FUEL_TYPE;
+
+import dev.bang.pickcar.car.dto.CarModelRequest;
+
+import dev.bang.pickcar.car.entity.CarModel;
+import dev.bang.pickcar.car.repository.CarModelRepository;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+@Component
+@ActiveProfiles("test")
+public class CarTestHelper {
+
+    @Autowired
+    private CarModelRepository carModelRepository;
+
+    private final AtomicLong counter = new AtomicLong();
+
+    public CarModelRequest createCarModelRequest() {
+        return new CarModelRequest(
+                VALID_CAR_BRAND_NAME,
+                VALID_CAR_MODEL_NAME,
+                VALID_CAR_GENERATION,
+                VALID_CAR_SEGMENT.name(),
+                VALID_CAR_TYPE.name(),
+                VALID_FUEL_TYPE.name(),
+                VALID_CAR_SEAT_CAPACITY
+        );
+    }
+
+    public CarModelRequest createCustomCarModelRequest(Object... args) {
+        return new CarModelRequest(
+                (String) args[0],
+                (String) args[1],
+                (String) args[2],
+                (String) args[3],
+                (String) args[4],
+                (String) args[5],
+                (int) args[6]
+        );
+    }
+
+    public CarModel createCarModel() {
+        String uniqueCarModelName = VALID_CAR_MODEL_NAME + counter.incrementAndGet();
+        CarModelRequest carModelRequest = createCustomCarModelRequest(
+                VALID_CAR_BRAND_NAME,
+                uniqueCarModelName,
+                VALID_CAR_GENERATION,
+                VALID_CAR_SEGMENT.name(),
+                VALID_CAR_TYPE.name(),
+                VALID_FUEL_TYPE.name(),
+                VALID_CAR_SEAT_CAPACITY
+        );
+        return carModelRepository.save(carModelRequest.toCarModel());
+    }
+
+    public CarModel createCarModel(CarModelRequest carModelRequest) {
+        return carModelRepository.save(carModelRequest.toCarModel());
+    }
+}

--- a/src/test/java/dev/bang/pickcar/car/controller/CarModelManageControllerTest.java
+++ b/src/test/java/dev/bang/pickcar/car/controller/CarModelManageControllerTest.java
@@ -1,0 +1,230 @@
+package dev.bang.pickcar.car.controller;
+
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+
+import dev.bang.pickcar.car.CarTestHelper;
+import dev.bang.pickcar.car.dto.CarModelRequest;
+import dev.bang.pickcar.member.MemberTestHelper;
+import dev.bang.pickcar.member.entity.Member;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("CarModelController 테스트")
+@ActiveProfiles("test")
+@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class CarModelManageControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberTestHelper memberTestHelper;
+
+    @Autowired
+    private CarTestHelper carTestHelper;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("관리자인 경우 새로운 차량 모델을 등록할 수 있다.")
+    @Test
+    void createCarModel() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        CarModelRequest carModelRequest = carTestHelper.createCarModelRequest();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(carModelRequest)
+                .when().post("models")
+                .then().log().all()
+                .statusCode(201);
+    }
+
+    @DisplayName("관리자가 아닌 경우 새로운 차량 모델을 등록할 수 없다.")
+    @Test
+    void createCarModel_Unauthorized() {
+        Member member = memberTestHelper.createMember();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(member);
+
+        CarModelRequest carModelRequest = carTestHelper.createCarModelRequest();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(carModelRequest)
+                .when().post("models")
+                .then().log().all()
+                .statusCode(403);
+    }
+
+    @DisplayName("같은 차량 모델이 이미 존재하는 경우 새로운 차량 모델을 등록할 수 없다.")
+    @Test
+    void createCarModel_Duplicate() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        CarModelRequest carModelRequest = carTestHelper.createCarModelRequest();
+        carTestHelper.createCarModel(carModelRequest);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(carModelRequest)
+                .when().post("models")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("관리자인 경우 차량 모델을 조회할 수 있다.")
+    @Test
+    void getCarModels() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("models")
+                .then().log().all()
+                .statusCode(200);
+    }
+
+    @DisplayName("존재하지 않는 차량 모델을 조회할 수 없다.")
+    @Test
+    void getCarModel_NotExist() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        long notExistCarModelId = 0L;
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("models/" + notExistCarModelId)
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("관리자가 아닌 경우 차량 모델을 조회할 수 없다.")
+    @Test
+    void getCarModels_Unauthorized() {
+        Member member = memberTestHelper.createMember();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(member);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("models")
+                .then().log().all()
+                .statusCode(403);
+    }
+
+    @DisplayName("관리자인 경우 특정 차량 모델을 조회할 수 있다.")
+    @Test
+    void getCarModel() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        Long carModelId = carTestHelper.createCarModel().getId();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("models/" + carModelId)
+                .then().log().all()
+                .statusCode(200);
+    }
+
+    @DisplayName("관리자가 아닌 경우 특정 차량 모델을 조회할 수 없다.")
+    @Test
+    void getCarModel_Unauthorized() {
+        Member member = memberTestHelper.createMember();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(member);
+
+        Long carModelId = carTestHelper.createCarModel().getId();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("models/" + carModelId)
+                .then().log().all()
+                .statusCode(403);
+    }
+
+    @DisplayName("차량 모델을 삭제한 경우 차량 모델을 조회할 수 없다.")
+    @Test
+    void getCarModel_NotFound() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        Long carModelId = carTestHelper.createCarModel().getId();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("models/" + carModelId)
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().get("models/" + carModelId)
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("관리자인 경우 특정 차량 모델을 삭제할 수 있다.")
+    @Test
+    void deleteCarModel() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        Long carModelId = carTestHelper.createCarModel().getId();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("models/" + carModelId)
+                .then().log().all()
+                .statusCode(204);
+    }
+
+    @DisplayName("관리자가 아닌 경우 특정 차량 모델을 삭제할 수 없다.")
+    @Test
+    void deleteCarModel_Unauthorized() {
+        Member member = memberTestHelper.createMember();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(member);
+
+        Long carModelId = carTestHelper.createCarModel().getId();
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("models/" + carModelId)
+                .then().log().all()
+                .statusCode(403);
+    }
+
+    @DisplayName("존재하지 않는 차량 모델을 삭제할 수 없다.")
+    @Test
+    void deleteCarModel_NotExist() {
+        Member admin = memberTestHelper.createAdmin();
+        String accessToken = memberTestHelper.getAccessTokenFromMember(admin);
+
+        long notExistCarModelId = 0L;
+
+        RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .when().delete("models/" + notExistCarModelId)
+                .then().log().all()
+                .statusCode(400);
+    }
+}

--- a/src/test/java/dev/bang/pickcar/car/entity/CarModelTest.java
+++ b/src/test/java/dev/bang/pickcar/car/entity/CarModelTest.java
@@ -1,0 +1,153 @@
+package dev.bang.pickcar.car.entity;
+
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_BRAND_NAME;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_GENERATION;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_MODEL_NAME;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_SEAT_CAPACITY;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_SEGMENT;
+import static dev.bang.pickcar.car.CarTestData.VALID_CAR_TYPE;
+import static dev.bang.pickcar.car.CarTestData.VALID_FUEL_TYPE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("자동차 모델 테스트")
+class CarModelTest {
+
+    @DisplayName("정상적인 자동차 모델 생성은 예외가 발생하지 않는다.")
+    @Test
+    void shouldNotThrowException_WhenValidCreate() {
+        assertThatCode(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        VALID_CAR_MODEL_NAME,
+                        VALID_CAR_GENERATION,
+                        VALID_CAR_SEGMENT,
+                        VALID_CAR_TYPE,
+                        VALID_FUEL_TYPE,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).doesNotThrowAnyException();
+    }
+
+    @DisplayName("자동차 모델 생성 시 브랜드 이름이 null 또는 빈 문자열인 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowException_WhenBrandNameIsNullOrEmpty(String brandName) {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        brandName,
+                        VALID_CAR_MODEL_NAME,
+                        VALID_CAR_GENERATION,
+                        VALID_CAR_SEGMENT,
+                        VALID_CAR_TYPE,
+                        VALID_FUEL_TYPE,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("자동차 모델 생성 시 모델 이름이 null 또는 빈 문자열인 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowException_WhenModelNameIsNullOrEmpty(String modelName) {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        modelName,
+                        VALID_CAR_GENERATION,
+                        VALID_CAR_SEGMENT,
+                        VALID_CAR_TYPE,
+                        VALID_FUEL_TYPE,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("자동차 모델 생성 시 세대가 null 또는 빈 문자열인 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowException_WhenGenerationIsNullOrEmpty(String generation) {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        VALID_CAR_MODEL_NAME,
+                        generation,
+                        VALID_CAR_SEGMENT,
+                        VALID_CAR_TYPE,
+                        VALID_FUEL_TYPE,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("자동차 모델 생성 시 세그먼트가 null인 경우 예외가 발생한다.")
+    @Test
+    void shouldThrowException_WhenSegmentIsNull() {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        VALID_CAR_MODEL_NAME,
+                        VALID_CAR_GENERATION,
+                        null,
+                        VALID_CAR_TYPE,
+                        VALID_FUEL_TYPE,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("자동차 모델 생성 시 차량 종류가 null인 경우 예외가 발생한다.")
+    @Test
+    void shouldThrowException_WhenCarTypeIsNull() {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        VALID_CAR_MODEL_NAME,
+                        VALID_CAR_GENERATION,
+                        VALID_CAR_SEGMENT,
+                        null,
+                        VALID_FUEL_TYPE,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("자동차 모델 생성 시 연료 타입이 null인 경우 예외가 발생한다.")
+    @Test
+    void shouldThrowException_WhenFuelTypeIsNull() {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        VALID_CAR_MODEL_NAME,
+                        VALID_CAR_GENERATION,
+                        VALID_CAR_SEGMENT,
+                        VALID_CAR_TYPE,
+                        null,
+                        VALID_CAR_SEAT_CAPACITY
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("자동차 모델 생성 시 좌석 수가 0 이하인 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void shouldThrowException_WhenSeatCapacityIsNotValid(int seatCapacity) {
+        assertThatThrownBy(() ->
+                new CarModel(
+                        VALID_CAR_BRAND_NAME,
+                        VALID_CAR_MODEL_NAME,
+                        VALID_CAR_GENERATION,
+                        VALID_CAR_SEGMENT,
+                        VALID_CAR_TYPE,
+                        VALID_FUEL_TYPE,
+                        seatCapacity
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/dev/bang/pickcar/member/MemberTestData.java
+++ b/src/test/java/dev/bang/pickcar/member/MemberTestData.java
@@ -13,6 +13,12 @@ public class MemberTestData {
     public static final LocalDate VALID_BIRTHDAY = LocalDate.of(2000, 1, 1);
     public static final String VALID_PHONE_NUMBER = PHONE_NUMBER_FORMAT;
 
+    public static final String ADMIN_NAME = "관리자";
+    public static final String ADMIN_NICKNAME = "admin";
+    public static final String ADMIN_EMAIL = "admin@gmail.com";
+    public static final String ADMIN_PASSWORD = "5E884898DA28047151D0E56F8DC6292773603D0D6AABBDD62A11EF721D1542D8";
+    public static final String ADMIN_PHONE_NUMBER = "01000001234";
+
     public static final String VERIFICATION_CODE = "123456";
 
     private MemberTestData() {

--- a/src/test/java/dev/bang/pickcar/member/MemberTestHelper.java
+++ b/src/test/java/dev/bang/pickcar/member/MemberTestHelper.java
@@ -1,5 +1,10 @@
 package dev.bang.pickcar.member;
 
+import static dev.bang.pickcar.member.MemberTestData.ADMIN_EMAIL;
+import static dev.bang.pickcar.member.MemberTestData.ADMIN_NAME;
+import static dev.bang.pickcar.member.MemberTestData.ADMIN_NICKNAME;
+import static dev.bang.pickcar.member.MemberTestData.ADMIN_PASSWORD;
+import static dev.bang.pickcar.member.MemberTestData.ADMIN_PHONE_NUMBER;
 import static dev.bang.pickcar.member.MemberTestData.VALID_BIRTHDAY;
 import static dev.bang.pickcar.member.MemberTestData.VALID_EMAIL;
 import static dev.bang.pickcar.member.MemberTestData.VALID_NAME;
@@ -12,6 +17,7 @@ import dev.bang.pickcar.auth.dto.MemberAuthResponse;
 import dev.bang.pickcar.auth.jwt.TokenProvider;
 import dev.bang.pickcar.member.dto.MemberRequest;
 import dev.bang.pickcar.member.entity.Member;
+import dev.bang.pickcar.member.entity.MemberRole;
 import dev.bang.pickcar.member.repository.MemberRepository;
 import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicLong;
@@ -61,16 +67,34 @@ public class MemberTestHelper {
 
     public Member createMember() {
         long uniqueValue = counter.incrementAndGet();
-        String uniqueEmail = String.format("test%d@example.com", uniqueValue);
         String uniqueNickname = String.format("tester%d", uniqueValue);
-        return memberRepository.save(new Member(
-                VALID_NAME,
-                uniqueNickname,
-                uniqueEmail,
-                VALID_PASSWORD,
-                VALID_BIRTHDAY,
-                VALID_PHONE_NUMBER
-        ));
+        String uniqueEmail = String.format("test%d@example.com", uniqueValue);
+        return memberRepository.save(
+                new Member(
+                        VALID_NAME,
+                        uniqueNickname,
+                        uniqueEmail,
+                        VALID_PASSWORD,
+                        VALID_BIRTHDAY,
+                        VALID_PHONE_NUMBER
+                )
+        );
+    }
+
+    public Member createAdmin() {
+        long uniqueValue = counter.incrementAndGet();
+        String uniqueNickname = String.format("admin%d", uniqueValue);
+        String uniqueEmail = String.format("admin%d@example.com", uniqueValue);
+        return memberRepository.save(
+                new Member(
+                        ADMIN_NAME,
+                        uniqueNickname,
+                        uniqueEmail,
+                        ADMIN_PASSWORD,
+                        ADMIN_PHONE_NUMBER,
+                        MemberRole.ADMIN
+                )
+        );
     }
 
     public String getAccessTokenFromMember(Member member) {

--- a/src/test/java/dev/bang/pickcar/member/MemberTestHelper.java
+++ b/src/test/java/dev/bang/pickcar/member/MemberTestHelper.java
@@ -1,8 +1,6 @@
 package dev.bang.pickcar.member;
 
-import static dev.bang.pickcar.member.MemberTestData.ADMIN_EMAIL;
 import static dev.bang.pickcar.member.MemberTestData.ADMIN_NAME;
-import static dev.bang.pickcar.member.MemberTestData.ADMIN_NICKNAME;
 import static dev.bang.pickcar.member.MemberTestData.ADMIN_PASSWORD;
 import static dev.bang.pickcar.member.MemberTestData.ADMIN_PHONE_NUMBER;
 import static dev.bang.pickcar.member.MemberTestData.VALID_BIRTHDAY;
@@ -31,6 +29,7 @@ public class MemberTestHelper {
 
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private TokenProvider tokenProvider;
 


### PR DESCRIPTION
## 요약

> 현대자동차의 쏘나타와 같이 관리자가 차량 모델을 관리할 수 있는 기능을 구현합니다. 관련 이슈: #19 

## 차량 모델 수정 기능 부재

제조사, 모델명, 세대, 연료 타입이 같은 경우 동일 모델로 간주합니다. 따라서 모델을 생성하거나 수정해야 하는 경우 모델 중복을 검증해야 합니다. 

차량 모델의 경우 관리자만 관리할 수 있으며, 추가되거나 수정될 일이 거의 없기 때문에 복잡성 감소를 위해 수정 기능을 구현하지 않았습니다. (차량 모델을 수정할 경우 같은 모델이 있는 지 검증해야 합니다.) 그래서 수정이 필요한 경우 삭제 후 다시 생성해야 합니다.

## 논리적 삭제

차량 모델이 더 이상 생산되지 않거나 매입하지 않을 경우에 대한 처리를 결정하지 않았기 때문에 논리적 삭제로 데이터를 유지할 수 있게 구현했습니다.

- `@Where` 어노테이션이 deprecate 되어 `@SQLRestriction`를 사용합니다.

## Enum 검증

차량 모델에는 여러 Enum이 존재합니다.  차량 모델 생성 API와 같이 해당 Enum에 맞게 요청해야 하는 경우 검증 로직 위치에 대한 고민입니다.

- 차량의 세그먼트 (예시: 준중형, 중형 등)
- 연료 타입 (예시: 가솔린, LPG 등)
- 차량 타입 (예시: 세단, SUV 등)

### 1. 차량 모델을 등록(추가)할 때 DTO에서 검증하기

처음에는 DTO에서 Enum에 등록한 값만 요청할 수 있게 구현하려고 했습니다. 

차량의 세그먼트, 연료 타입 등은 변경 가능성이 매우 낮은 편이고 어차피 올바른 값이 아닌 경우에는 내부 로직까지 들어갈 필요 없이 바깥 지점에서 거절하는 방식이 효율적이라고 생각했습니다.

> `ConstraintValidator`를 구현하여 검증 컴포넌트를 구현하고 어노테이션을 추가하여 DTO 필드에서 검증될 수 있게 구현하기

```java
// DTO 필드 예시
@ValidEnum(enumClass = FuelType.class, message = "유효한 연료 타입을 입력해주세요.")
String fuelType // 미리 지정한 타입이 아닌 경우 예외 발생
```

유효한 값이 포함된 요청만 처리됩니다. 그러나 끝 지점에서 받은 Enum 값이 가장 내부인 영속 계층까지 영향을 준다는 단점이 있었습니다. 변경에 취약합니다. 또한, `DTO는 값을 안전하게 전달하는 상자 같은 역할을 수행해야 하는데, 마치 상자가 안에 내용물을 검증하는 상황이 발생`한다고 볼 수 있습니다. 그래서 이 방법은 사용하지 않았습니다.

### 2. Enum 클래스의 valueOf() 상속 or  Enum의 예외를 그대로 사용

Enum의 valueOf() 메서드는 문자열을 받아서 Enum의 name이 일치하는 인스턴스를 반환하는 메서드입니다. 이때 존재하지 않는 name을 전달한 경우 발생하는 예외를 커스텀하는 방식을 고민할 수 있습니다.

그러나 Enum 클래스의 valueOf() 메서드는 재정의를 지원하지 않습니다.

앞서 설명한 valueOf() 메서드를 사용할 때 존재하지 않는 name을 전달하는 경우 `No enum constant...`로 시작하는 `IllegalArgumentException`이 발생합니다. 이미 해당 예외를 핸들링하고 있었기 때문에 메시지를 가공하는 방식을 사용할 수 있었습니다.

```java
@ExceptionHandler(IllegalArgumentException.class)
public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
    log.warn("IllegalArgumentException: {}", exception.getMessage());
    // No enum constant..로 시작하는 예외 메시지인 경우 가공해서 특정 필드를 확인해 달라는 메시지로 가공하여 반환
    return ResponseEntity.badRequest()
            .body(exception.getMessage());
}
```

그러나 이 구조는 Java Enum 예외 메시지가 변경되는 것처럼 외부 변경에 취약해집니다. 또한 valueOf() 메서드에서 발생하는 예외가 `No enum constant...`로 시작한다는 내용을 모르는 개발자인 경우 이해할 수 없는 코드가 될 가능성이 높습니다. 그래서 선택하지 않았습니다..

### 3. 정적 메서드 구현

```java
// 연료 타입 Enum
public static FuelType from(String fuelType) {
    try {
        return FuelType.valueOf(fuelType.toUpperCase());
    } catch (IllegalArgumentException e) {
        throw new IllegalArgumentException("유효한 연료 타입을 입력해주세요. e.g. GASOLINE, DIESEL, ELECTRIC, HYBRID, LPG, HYDROGEN");
    }
}
```
valueOf()를 사용하다가 예외가 발생한 경우 내부에서 메시지를 가공해서 던질 수 있게 구현했습니다.

중복 코드가 많이 작성될 위험이 있지만, 현재는 크지 않고 만약 그렇게 되는 경우 하나의 유틸로 추출하거나 인터페이스에 default 메서드를 작성하고 구현하는 방식으로 중복을 줄일 수 있을 것 같아서 우선 이렇게 구현했습니다.

## 기타 내용

- MethodSecurity를 활성화하여 역할 검증이 수행될 수 있도록 합니다.
- 생일 필드 검증 로직을 수정합니다.