### PR TITLE
[Invalid] 공통 응답 형식 구현

### DIFF
--- a/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/AuthController.java
@@ -2,20 +2,20 @@ package dev.bang.pickcar.auth.controller;
 
 import dev.bang.pickcar.auth.controller.docs.AuthApiDocs;
 import dev.bang.pickcar.auth.controller.facade.AuthFacade;
+import dev.bang.pickcar.auth.dto.EmailRequest;
 import dev.bang.pickcar.auth.dto.EmailVerifyRequest;
 import dev.bang.pickcar.auth.dto.LoginRequest;
+import dev.bang.pickcar.auth.dto.PhoneNumberRequest;
 import dev.bang.pickcar.auth.dto.TokenResponse;
+import dev.bang.pickcar.auth.dto.VerificationCodeResponse;
 import dev.bang.pickcar.member.dto.MemberRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,37 +39,37 @@ public class AuthController implements AuthApiDocs {
         return ResponseEntity.ok(token);
     }
 
-    @PostMapping("check/email/{email}")
+    @PostMapping("check/email")
     @Override
-    public ResponseEntity<Boolean> checkEmailDuplication(@PathVariable(name = "email") String email) {
-        return ResponseEntity.ok(authFacade.checkEmailDuplication(email));
+    public ResponseEntity<Boolean> checkEmailDuplication(@RequestBody @Valid EmailRequest req) {
+        return ResponseEntity.ok(authFacade.checkEmailDuplication(req.email()));
     }
 
-    @PostMapping("verification/send/email/{email}")
+    @PostMapping("verification/email/send")
     @Override
-    public ResponseEntity<Void> sendVerificationCodeToEmail(@PathVariable(name = "email") String email) {
-        authFacade.sendVerificationCodeToEmail(email);
+    public ResponseEntity<Void> sendVerificationCodeToEmail(@RequestBody @Valid EmailRequest req) {
+        authFacade.sendVerificationCodeToEmail(req.email());
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("verification/verify/email")
+    @PostMapping("verification/email/verify")
     @Override
     public ResponseEntity<Void> verifyEmail(@RequestBody @Valid EmailVerifyRequest emailVerifyRequest) {
-        boolean isVerified = authFacade.verifyEmail(emailVerifyRequest.email(), emailVerifyRequest.verificationCode());
-        return isVerified ? ResponseEntity.ok().build() : ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        authFacade.verifyEmail(emailVerifyRequest.email(), emailVerifyRequest.verificationCode());
+        return ResponseEntity.ok().build();
     }
 
-    @PostMapping("verification/issue")
+    @PostMapping("verification/phone/code")
     @Override
-    public ResponseEntity<String> issueVerificationCode(@RequestParam String phoneNumber) {
-        String verificationCode = authFacade.issueVerificationCode(phoneNumber);
+    public ResponseEntity<VerificationCodeResponse> issueVerificationCode(@RequestBody @Valid PhoneNumberRequest req) {
+        VerificationCodeResponse verificationCode = authFacade.issueVerificationCode(req.phoneNumber());
         return ResponseEntity.ok(verificationCode);
     }
 
-    @PostMapping("verification/verify")
+    @PostMapping("verification/phone/verify")
     @Override
-    public ResponseEntity<Void> verifyVerificationNumber(@RequestParam String phoneNumber) {
-        authFacade.verifyPhoneNumber(phoneNumber);
+    public ResponseEntity<Void> verifyVerificationNumber(@RequestBody @Valid PhoneNumberRequest req) {
+        authFacade.verifyPhoneNumber(req.phoneNumber());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/dev/bang/pickcar/auth/controller/docs/AuthApiDocs.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/docs/AuthApiDocs.java
@@ -1,8 +1,11 @@
 package dev.bang.pickcar.auth.controller.docs;
 
+import dev.bang.pickcar.auth.dto.EmailRequest;
 import dev.bang.pickcar.auth.dto.EmailVerifyRequest;
 import dev.bang.pickcar.auth.dto.LoginRequest;
+import dev.bang.pickcar.auth.dto.PhoneNumberRequest;
 import dev.bang.pickcar.auth.dto.TokenResponse;
+import dev.bang.pickcar.auth.dto.VerificationCodeResponse;
 import dev.bang.pickcar.member.dto.MemberRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -32,14 +35,14 @@ public interface AuthApiDocs {
             @ApiResponse(responseCode = "200", description = "이메일 중복 확인 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
-    ResponseEntity<Boolean> checkEmailDuplication(String email);
+    ResponseEntity<Boolean> checkEmailDuplication(EmailRequest emailRequest);
 
     @Operation(summary = "(이메일) 인증번호 전송", description = "이메일 인증을 위한 인증번호를 전송합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "인증번호 전송 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
-    ResponseEntity<Void> sendVerificationCodeToEmail(String email);
+    ResponseEntity<Void> sendVerificationCodeToEmail(EmailRequest emailRequest);
 
     @Operation(summary = "(이메일) 인증번호 확인", description = "이메일 인증을 위한 인증번호를 확인합니다.")
     @ApiResponses(value = {
@@ -53,12 +56,12 @@ public interface AuthApiDocs {
             @ApiResponse(responseCode = "200", description = "인증번호 발급 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
-    ResponseEntity<String> issueVerificationCode(String phoneNumber);
+    ResponseEntity<VerificationCodeResponse> issueVerificationCode(PhoneNumberRequest phoneNumberRequest);
 
     @Operation(summary = "인증번호 확인", description = "휴대폰 번호 인증을 위한 인증번호를 확인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "인증번호 확인 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
-    ResponseEntity<Void> verifyVerificationNumber(String phoneNumber);
+    ResponseEntity<Void> verifyVerificationNumber(PhoneNumberRequest phoneNumberRequest);
 }

--- a/src/main/java/dev/bang/pickcar/auth/controller/facade/AuthFacade.java
+++ b/src/main/java/dev/bang/pickcar/auth/controller/facade/AuthFacade.java
@@ -3,6 +3,7 @@ package dev.bang.pickcar.auth.controller.facade;
 import dev.bang.pickcar.auth.dto.LoginRequest;
 import dev.bang.pickcar.auth.dto.MemberAuthResponse;
 import dev.bang.pickcar.auth.dto.TokenResponse;
+import dev.bang.pickcar.auth.dto.VerificationCodeResponse;
 import dev.bang.pickcar.auth.service.AuthService;
 import dev.bang.pickcar.auth.service.VerificationService;
 import dev.bang.pickcar.member.dto.MemberRequest;
@@ -41,12 +42,12 @@ public class AuthFacade {
         verificationService.sendVerificationCodeToEmail(email);
     }
 
-    public boolean verifyEmail(String email, String verificationCode) {
-        return verificationService.verifyEmail(email, verificationCode);
+    public void verifyEmail(String email, String verificationCode) {
+        verificationService.verifyEmail(email, verificationCode);
     }
 
-    public String issueVerificationCode(String identifier) {
-        return verificationService.generateVerificationCode(identifier);
+    public VerificationCodeResponse issueVerificationCode(String identifier) {
+        return new VerificationCodeResponse(verificationService.generateVerificationCode(identifier));
     }
 
     public void verifyPhoneNumber(String phoneNumber) {

--- a/src/main/java/dev/bang/pickcar/auth/dto/EmailRequest.java
+++ b/src/main/java/dev/bang/pickcar/auth/dto/EmailRequest.java
@@ -1,0 +1,9 @@
+package dev.bang.pickcar.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        String email
+) {
+}

--- a/src/main/java/dev/bang/pickcar/auth/dto/PhoneNumberRequest.java
+++ b/src/main/java/dev/bang/pickcar/auth/dto/PhoneNumberRequest.java
@@ -1,0 +1,9 @@
+package dev.bang.pickcar.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PhoneNumberRequest(
+        @NotBlank(message = "전화번호를 입력해주세요.")
+        String phoneNumber
+) {
+}

--- a/src/main/java/dev/bang/pickcar/auth/dto/VerificationCodeResponse.java
+++ b/src/main/java/dev/bang/pickcar/auth/dto/VerificationCodeResponse.java
@@ -1,0 +1,6 @@
+package dev.bang.pickcar.auth.dto;
+
+public record VerificationCodeResponse(
+        String verificationCode
+) {
+}

--- a/src/main/java/dev/bang/pickcar/auth/service/VerificationService.java
+++ b/src/main/java/dev/bang/pickcar/auth/service/VerificationService.java
@@ -53,14 +53,13 @@ public class VerificationService {
         );
     }
 
-    public boolean verifyEmail(String email, String verificationCode) {
+    public void verifyEmail(String email, String verificationCode) {
         String savedVerificationCode = verificationCodeRepository.findByIdentifier(email);
         boolean isVerified = savedVerificationCode.equals(verificationCode);
         if (!isVerified) {
             throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
         }
         verificationCodeRepository.completeVerification(email);
-        return true;
     }
 
     public void checkVerifiedEmail(String email) {

--- a/src/main/java/dev/bang/pickcar/global/config/SecurityConfig.java
+++ b/src/main/java/dev/bang/pickcar/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package dev.bang.pickcar.global.config;
 
 import dev.bang.pickcar.auth.jwt.JwtFilter;
 import dev.bang.pickcar.global.config.properties.SecurityProperties;
+import dev.bang.pickcar.global.exception.GlobalAccessDeniedHandler;
+import dev.bang.pickcar.global.exception.GlobalAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +12,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -28,6 +31,8 @@ public class SecurityConfig {
 
     private final SecurityProperties securityProperties;
     private final JwtFilter jwtFilter;
+    private final GlobalAccessDeniedHandler globalAccessDeniedHandler;
+    private final GlobalAuthenticationEntryPoint globalAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -44,6 +49,7 @@ public class SecurityConfig {
                                 .requestMatchers(getWhitelistedMatchers()).permitAll()
                                 .anyRequest().authenticated()
                 )
+                .exceptionHandling(this::configureExceptionHandling)
                 .build();
     }
 
@@ -65,5 +71,10 @@ public class SecurityConfig {
 
     private void configureSessionManagement(SessionManagementConfigurer<HttpSecurity> session) {
         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+    }
+
+    void configureExceptionHandling(ExceptionHandlingConfigurer<HttpSecurity> config) {
+        config.accessDeniedHandler(globalAccessDeniedHandler)
+                .authenticationEntryPoint(globalAuthenticationEntryPoint);
     }
 }

--- a/src/main/java/dev/bang/pickcar/global/exception/ErrorResponse.java
+++ b/src/main/java/dev/bang/pickcar/global/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package dev.bang.pickcar.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse badRequest(String message) {
+        return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), message);
+    }
+
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+}

--- a/src/main/java/dev/bang/pickcar/global/exception/GlobalAccessDeniedHandler.java
+++ b/src/main/java/dev/bang/pickcar/global/exception/GlobalAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package dev.bang.pickcar.global.exception;
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Security, 접근 권한이 없는 경우 발생하는 예외를 처리하는 클래스입니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GlobalAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final Gson gson;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        log.warn("AccessDeniedException: {}", accessDeniedException.getMessage());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.");
+        response.getWriter().write(gson.toJson(errorResponse));
+    }
+}

--- a/src/main/java/dev/bang/pickcar/global/exception/GlobalAuthenticationEntryPoint.java
+++ b/src/main/java/dev/bang/pickcar/global/exception/GlobalAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package dev.bang.pickcar.global.exception;
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Security, 인증이 필요한 경우 발생하는 예외를 처리하는 클래스입니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GlobalAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final Gson gson;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        log.warn("AuthenticationException: {}", authException.getMessage());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다.");
+        response.getWriter().write(gson.toJson(errorResponse));
+    }
+}

--- a/src/main/java/dev/bang/pickcar/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/bang/pickcar/global/exception/GlobalExceptionHandler.java
@@ -14,27 +14,31 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
         log.warn("IllegalArgumentException: {}", exception.getMessage());
         return ResponseEntity.badRequest()
-                .body(exception.getMessage());
+                .body(ErrorResponse.badRequest(exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
         log.warn("MethodArgumentNotValidException: {}", exception.getMessage());
         return ResponseEntity.badRequest()
-                .body(exception.getBindingResult()
-                        .getFieldErrors()
-                        .stream()
-                        .map(FieldError::getDefaultMessage)
-                        .collect(Collectors.joining("\n")));
+                .body(ErrorResponse.badRequest(collectErrorFields(exception)));
+    }
+
+    private String collectErrorFields(MethodArgumentNotValidException exception) {
+        return exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining("\n"));
     }
 
     @ExceptionHandler(PaymentException.class)
-    public ResponseEntity<String> handlePaymentException(PaymentException exception) {
+    public ResponseEntity<ErrorResponse> handlePayment(PaymentException exception) {
         log.warn("PaymentException: {}", exception.getMessage());
         return ResponseEntity.badRequest()
-                .body(exception.getMessage());
+                .body(ErrorResponse.badRequest(exception.getMessage()));
     }
 }

--- a/src/main/java/dev/bang/pickcar/global/response/ApiResponse.java
+++ b/src/main/java/dev/bang/pickcar/global/response/ApiResponse.java
@@ -1,0 +1,16 @@
+package dev.bang.pickcar.global.response;
+
+import org.springframework.http.HttpStatus;
+
+public record ApiResponse(
+        int status,
+        Object data
+) {
+    public static ApiResponse success(Object data) {
+        return new ApiResponse(HttpStatus.OK.value(), data);
+    }
+
+    public static ApiResponse of(int status, Object data) {
+        return new ApiResponse(status, data);
+    }
+}

--- a/src/main/java/dev/bang/pickcar/global/response/GlobalResponseHandler.java
+++ b/src/main/java/dev/bang/pickcar/global/response/GlobalResponseHandler.java
@@ -1,0 +1,42 @@
+package dev.bang.pickcar.global.response;
+
+import dev.bang.pickcar.global.exception.GlobalExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(@NonNull MethodParameter returnType,
+                            @NonNull Class<? extends HttpMessageConverter<?>> converterType) {
+        return !isHandlingException(returnType);
+    }
+
+    private boolean isHandlingException(MethodParameter returnType) {
+        return returnType.getContainingClass().equals(GlobalExceptionHandler.class);
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  @NonNull MethodParameter returnType,
+                                  @NonNull MediaType selectedContentType,
+                                  @NonNull Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  @NonNull ServerHttpRequest request,
+                                  @NonNull ServerHttpResponse response) {
+        if (response instanceof ServletServerHttpResponse servletResponse) {
+            int statusCode = servletResponse.getServletResponse().getStatus();
+            return ApiResponse.of(statusCode, body);
+        }
+        return ApiResponse.success(body);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,7 +5,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/dev/bang/pickcar/pickzone/controller/PickZoneQueryControllerTest.java
+++ b/src/test/java/dev/bang/pickcar/pickzone/controller/PickZoneQueryControllerTest.java
@@ -58,7 +58,7 @@ class PickZoneQueryControllerTest {
                 .when().post("pick-zones/nearby")
                 .then().log().all()
                 .statusCode(200)
-                .body("size()", equalTo(1));
+                .body("data.size()", equalTo(1));
     }
 
     @DisplayName("id로 픽존을 조회할 수 있다.")


### PR DESCRIPTION
## 요약

> API 응답 형태를 표준화합니다. 관련 이슈: #35 

## 공통 응답 형식

성공한 경우와 예외가 발생한 경우를 구분하여 응답합니다.

- 클라이언트의 편의성을 위해 HTTP 상태 코드를 본문에 포함시켜 반환합니다. 이를 통해, 클라이언트는 별도의 상태 코드 확인 없이 응답 본문만으로 결과를 직관적으로 파악할 수 있습니다.
- 추가로 본문에 응답 시간을 작성해도 될 것 같은데, 필요한 부분이 있을지 검토 중입니다.

```json
{
    "status" : 200,
    "data" : "API 응답 결과"
}

{
    "status" : 403,
    "message" : "접근 권한이 없습니다."
}
```

모든 API에서 반환 값을 변경하지 않고, ResponseBodyAdvice를 활용하여 응답 본문만 수정하도록 구현하였습니다. 직접 핸들링하는 예외는 예외적으로 별도 처리가 가능합니다.

## Spring Security 예외 응답

- `AccessDeniedHandler`, `AuthenticationEntryPoint`를 구현하여 Spring Security의 인증 및 인가 관련 예외가 발생했을 때, 공통 응답 형식으로 반환되도록 처리했습니다.

## 인증 관련 API 인터페이스 변경

- URI를 보다 직관적으로 변경했습니다. 두 개의 인증 관련 URI는 `휴대폰`과 `이메일`로 분기되도록 구성했습니다.
- 민감한 정보를 URI로 노출하지 않도록 개선했습니다. 전화번호나 이메일 주소 같은 민감한 정보를 URI에 포함시키지 않고 요청 본문으로 받도록 변경하였습니다.